### PR TITLE
Handle 4 best practice proforma sequences

### DIFF
--- a/src/TopDownProteomics/ProForma/ProFormaDescriptor.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaDescriptor.cs
@@ -14,11 +14,12 @@ namespace TopDownProteomics.ProForma
         /// <param name="value">The value.</param>
         public ProFormaDescriptor(string key, string value)
         {
-            if (Enum.TryParse(key, true, out ProFormaKey parsedKey))
-                this.Key = parsedKey;
-            else
-                throw new ProFormaParseException("The key " + key + " is not supported.");
+            //if (Enum.TryParse(key, true, out ProFormaKey parsedKey))
+            //    this.Key = parsedKey;
+            //else
+            //    throw new ProFormaParseException("The key " + key + " is not supported.");
 
+            this.Key = key;
             this.Value = value;
         }
 
@@ -33,12 +34,12 @@ namespace TopDownProteomics.ProForma
         }
 
         /// <summary>
-        /// Gets the key.
+        /// The key.
         /// </summary>
-        public ProFormaKey Key { get; }
+        public string Key { get; }
 
         /// <summary>
-        /// Gets the value.
+        /// The value.
         /// </summary>
         public string Value { get; }
     }

--- a/src/TopDownProteomics/ProForma/ProFormaKey.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaKey.cs
@@ -3,26 +3,41 @@
     /// <summary>
     /// Possible keys for a ProFormaDescriptor
     /// </summary>
-    public enum ProFormaKey
+    public class ProFormaKey
     {
         /// <summary>
-        /// The modification
+        /// The modification name
         /// </summary>
-        Mod,
+        public static string Mod = "mod";
+
+        /// <summary>
+        /// The Unimod database identifier
+        /// </summary>
+        public static string Unimod = "Unimod";
+
+        /// <summary>
+        /// The RESID database identifier
+        /// </summary>
+        public static string Resid = "RESID";
+
+        /// <summary>
+        /// The PSI-MOD database identifier
+        /// </summary>
+        public static string PsiMod = "PSI-MOD";
 
         /// <summary>
         /// The mass
         /// </summary>
-        Mass,
+        public static string Mass = "mass";
 
         /// <summary>
         /// The formula (in Unimod notation)
         /// </summary>
-        Formula,
+        public static string Formula = "formula";
 
         /// <summary>
         /// The user defined extra information
         /// </summary>
-        Info
+        public static string Info = "info";
     }
 }

--- a/src/TopDownProteomics/ProForma/ProFormaParser.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaParser.cs
@@ -112,7 +112,7 @@ namespace TopDownProteomics.ProForma
             for (int i = 0; i < descriptorText.Length; i++)
             {
                 int colon = descriptorText[i].IndexOf(':');
-                string key = colon < 0 ? "" : descriptorText[i].Substring(0, colon);
+                string key = colon < 0 ? "" : descriptorText[i].Substring(0, colon).TrimStart();
                 string value = descriptorText[i].Substring(colon + 1); // values may have colons
 
                 if (!string.IsNullOrEmpty(prefixTag))

--- a/src/TopDownProteomics/ProForma/ProFormaTag.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaTag.cs
@@ -12,7 +12,7 @@ namespace TopDownProteomics.ProForma
         /// </summary>
         /// <param name="index">The index.</param>
         /// <param name="descriptors">The descriptors.</param>
-        public ProFormaTag(int index, ICollection<ProFormaDescriptor> descriptors)
+        public ProFormaTag(int index, IList<ProFormaDescriptor> descriptors)
         {
             Index = index;
             Descriptors = descriptors;
@@ -26,6 +26,6 @@ namespace TopDownProteomics.ProForma
         /// <summary>
         /// Gets the descriptors.
         /// </summary>
-        public ICollection<ProFormaDescriptor> Descriptors { get; }
+        public IList<ProFormaDescriptor> Descriptors { get; }
     }
 }

--- a/tests/TopDownProteomics.Tests/ProFormaParserTests.cs
+++ b/tests/TopDownProteomics.Tests/ProFormaParserTests.cs
@@ -43,6 +43,32 @@ namespace TestProject1
         }
 
         [Test]
+        public void HandleExtraTagSpaces()
+        {
+            var term = _parser.ParseString("PRO[info:test]TEOFORM");
+            Assert.AreEqual(ProFormaKey.Info, term.Tags.Single().Descriptors[0].Key);
+            Assert.AreEqual("test", term.Tags.Single().Descriptors[0].Value);
+
+            // Trim extra spaces from beginning of the descriptor
+            term = _parser.ParseString("PRO[ info:test]TEOFORM");
+            Assert.AreEqual(ProFormaKey.Info, term.Tags.Single().Descriptors[0].Key);
+            Assert.AreEqual("test", term.Tags.Single().Descriptors[0].Value);
+
+            term = _parser.ParseString("PRO[info:test ]TEOFORM");
+            Assert.AreEqual(ProFormaKey.Info, term.Tags.Single().Descriptors[0].Key);
+            Assert.AreEqual("test ", term.Tags.Single().Descriptors[0].Value);
+
+            term = _parser.ParseString("PRO[     info:test  ]TEOFORM");
+            Assert.AreEqual(ProFormaKey.Info, term.Tags.Single().Descriptors[0].Key);
+            Assert.AreEqual("test  ", term.Tags.Single().Descriptors[0].Value);
+
+            // Keep everything after the colon
+            term = _parser.ParseString("PRO[info: test]TEOFORM");
+            Assert.AreEqual(ProFormaKey.Info, term.Tags.Single().Descriptors[0].Key);
+            Assert.AreEqual(" test", term.Tags.Single().Descriptors[0].Value);
+        }
+
+        [Test]
         public void MultipleDescriptorTag()
         {
             const string proFormaString = "SEQUEN[mod:Methyl|mass:+14.02]CE";
@@ -56,10 +82,10 @@ namespace TestProject1
             Assert.AreEqual(5, tag.Index);
             Assert.AreEqual(2, tag.Descriptors.Count);
 
-            Assert.AreEqual(ProFormaKey.Mod, tag.Descriptors.First().Key);
-            Assert.AreEqual("Methyl", tag.Descriptors.First().Value);
-            Assert.AreEqual(ProFormaKey.Mass, tag.Descriptors.Last().Key);
-            Assert.AreEqual("+14.02", tag.Descriptors.Last().Value);
+            Assert.AreEqual(ProFormaKey.Mod, tag.Descriptors[0].Key);
+            Assert.AreEqual("Methyl", tag.Descriptors[0].Value);
+            Assert.AreEqual(ProFormaKey.Mass, tag.Descriptors[1].Key);
+            Assert.AreEqual("+14.02", tag.Descriptors[1].Value);
         }
 
         [Test]
@@ -193,49 +219,136 @@ namespace TestProject1
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString(proFormaString));
         }
 
-        // Best Practice examples should be made into unit/integration tests
-        //[Acetyl]-S[Phospho|mass:79.966331]GRGK[Acetyl|Unimod:1|mass:42.010565]QGGKARAKAKTRSSRAGLQFPVGRVHRLLRKGNYAERVGAGAPVYLAAVLEYLTAEILELAGNAARDNKKTRIIPRHLQLAIRNDEELNKLLGKVTIAQGGVLPNIQAVLLPKKT[Unimod:21]ESHHKAKGK
-        //[Unimod]+[1]-S[21]GRGK[1]QGGKARAKAKTRSSRAGKVTIAQGGVLPNIQAVLLPKKT[21]ESHHKAKGK
-        //MTLFQLREHWFVYKDDEKLTAFRNK[p-adenosine| N6-(phospho-5'-adenosine)-L-lysine (RESID)| RESID:AA0227| PSI-MOD:MOD:00232| N6AMPLys(PSI-MOD)]SMLFQRELRPNEEVTWK
-        //MTLFQLDEKLTA[mass:-37.995001|info:unknown modification]FRNKSMLFQRELRPNEEVTWK
+        [Test]
+        public void BestPractice_i()
+        {
+            const string proFormaString = "[Acetyl]-S[Phospho|mass:79.966331]GRGK[Acetyl|Unimod:1|mass:42.010565]QGGKARAKAKTRSSRAGLQFPVGRVHRLLRKGNYAERVGAGAPVYLAAVLEYLTAEILELAGNAARDNKKTRIIPRHLQLAIRNDEELNKLLGKVTIAQGGVLPNIQAVLLPKKT[Unimod:21]ESHHKAKGK";
+            var term = _parser.ParseString(proFormaString);
 
-        //[Test]
-        //public void BestPractice_ii()
-        //{
-        //    const string proFormaString = "[Unimod]+[1]-S[21]GRGK[1]QGGKARAKAKTRSSRAGKVTIAQGGVLPNIQAVLLPKKT[21]ESHHKAKGK";
-        //    var term = _parser.ParseString(proFormaString);
+            Assert.AreEqual("SGRGKQGGKARAKAKTRSSRAGLQFPVGRVHRLLRKGNYAERVGAGAPVYLAAVLEYLTAEILELAGNAARDNKKTRIIPRHLQLAIRNDEELNKLLGKVTIAQGGVLPNIQAVLLPKKTESHHKAKGK", term.Sequence);
+            Assert.IsNotNull(term.Tags);
+            Assert.AreEqual(3, term.Tags.Count);
+            Assert.IsNotNull(term.NTerminalDescriptors);
+            Assert.AreEqual(1, term.NTerminalDescriptors.Count);
+            Assert.IsNull(term.CTerminalDescriptors);
 
-        //    Assert.AreEqual("SGRGKQGGKARAKAKTRSSRAGKVTIAQGGVLPNIQAVLLPKKTESHHKAKGK", term.Sequence);
-        //    Assert.IsNotNull(term.Tags);
-        //    Assert.AreEqual(3, term.Tags.Count);
-        //    Assert.IsNotNull(term.NTerminalDescriptors);
-        //    Assert.AreEqual(1, term.NTerminalDescriptors.Count);
-        //    Assert.IsNull(term.CTerminalDescriptors);
+            var nTerm = term.NTerminalDescriptors[0];
+            Assert.AreEqual(ProFormaKey.Mod, nTerm.Key);
+            Assert.AreEqual("Acetyl", nTerm.Value);
 
-        //    var nTerm = term.NTerminalDescriptors[0];
-        //    Assert.AreEqual(ProFormaKey.Mod, nTerm.Key);
-        //    Assert.AreEqual("1", nTerm.Value);
+            ProFormaTag tag1 = term.Tags[0];
+            Assert.AreEqual(0, tag1.Index);
+            Assert.AreEqual(2, tag1.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Mod, tag1.Descriptors.First().Key);
+            Assert.AreEqual("Phospho", tag1.Descriptors.First().Value);
+            Assert.AreEqual(ProFormaKey.Mass, tag1.Descriptors.Last().Key);
+            Assert.AreEqual("79.966331", tag1.Descriptors.Last().Value);
 
-        //    ProFormaTag tag1 = term.Tags[0];
-        //    Assert.AreEqual(0, tag1.Index);
-        //    Assert.AreEqual(1, tag1.Descriptors.Count);
-        //    Assert.AreEqual(ProFormaKey.Mod, tag1.Descriptors.Single().Key);
-        //    Assert.AreEqual("21", tag1.Descriptors.Single().Value);
+            ProFormaTag tag5 = term.Tags[1];
+            Assert.AreEqual(4, tag5.Index);
+            Assert.AreEqual(3, tag5.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Mod, tag5.Descriptors[0].Key);
+            Assert.AreEqual("Acetyl", tag5.Descriptors[0].Value);
+            Assert.AreEqual(ProFormaKey.Unimod, tag5.Descriptors[1].Key);
+            Assert.AreEqual("1", tag5.Descriptors[1].Value);
+            Assert.AreEqual(ProFormaKey.Mass, tag5.Descriptors[2].Key);
+            Assert.AreEqual("42.010565", tag5.Descriptors[2].Value);
 
-        //    ProFormaTag tag5 = term.Tags[1];
-        //    Assert.AreEqual(4, tag5.Index);
-        //    Assert.AreEqual(1, tag5.Descriptors.Count);
-        //    Assert.AreEqual(ProFormaKey.Mod, tag5.Descriptors.Single().Key);
-        //    Assert.AreEqual("1", tag5.Descriptors.Single().Value);
-
-        //    ProFormaTag tag44 = term.Tags[2];
-        //    Assert.AreEqual(43, tag44.Index);
-        //    Assert.AreEqual(1, tag44.Descriptors.Count);
-        //    Assert.AreEqual(ProFormaKey.Mod, tag44.Descriptors.Single().Key);
-        //    Assert.AreEqual("21", tag44.Descriptors.Single().Value);
-        //}
+            ProFormaTag tag120 = term.Tags[2];
+            Assert.AreEqual(119, tag120.Index);
+            Assert.AreEqual(1, tag120.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Unimod, tag120.Descriptors.Single().Key);
+            Assert.AreEqual("21", tag120.Descriptors.Single().Value);
+        }
 
         [Test]
+        public void BestPractice_ii()
+        {
+            const string proFormaString = "[Unimod]+[1]-S[21]GRGK[1]QGGKARAKAKTRSSRAGKVTIAQGGVLPNIQAVLLPKKT[21]ESHHKAKGK";
+            var term = _parser.ParseString(proFormaString);
+
+            Assert.AreEqual("SGRGKQGGKARAKAKTRSSRAGKVTIAQGGVLPNIQAVLLPKKTESHHKAKGK", term.Sequence);
+            Assert.IsNotNull(term.Tags);
+            Assert.AreEqual(3, term.Tags.Count);
+            Assert.IsNotNull(term.NTerminalDescriptors);
+            Assert.AreEqual(1, term.NTerminalDescriptors.Count);
+            Assert.IsNull(term.CTerminalDescriptors);
+
+            var nTerm = term.NTerminalDescriptors[0];
+            Assert.AreEqual(ProFormaKey.Unimod, nTerm.Key);
+            Assert.AreEqual("1", nTerm.Value);
+
+            ProFormaTag tag1 = term.Tags[0];
+            Assert.AreEqual(0, tag1.Index);
+            Assert.AreEqual(1, tag1.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Unimod, tag1.Descriptors.Single().Key);
+            Assert.AreEqual("21", tag1.Descriptors.Single().Value);
+
+            ProFormaTag tag5 = term.Tags[1];
+            Assert.AreEqual(4, tag5.Index);
+            Assert.AreEqual(1, tag5.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Unimod, tag5.Descriptors.Single().Key);
+            Assert.AreEqual("1", tag5.Descriptors.Single().Value);
+
+            ProFormaTag tag44 = term.Tags[2];
+            Assert.AreEqual(43, tag44.Index);
+            Assert.AreEqual(1, tag44.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Unimod, tag44.Descriptors.Single().Key);
+            Assert.AreEqual("21", tag44.Descriptors.Single().Value);
+        }
+
+        [Test]
+        public void BestPractice_iii()
+        {
+            const string proFormaString = "MTLFQLREHWFVYKDDEKLTAFRNK[p-adenosine| N6-(phospho-5'-adenosine)-L-lysine(RESID)| RESID:AA0227| PSI-MOD:MOD:00232| N6AMPLys(PSI-MOD)]SMLFQRELRPNEEVTWK";
+            var term = _parser.ParseString(proFormaString);
+
+            Assert.AreEqual("MTLFQLREHWFVYKDDEKLTAFRNKSMLFQRELRPNEEVTWK", term.Sequence);
+            Assert.IsNotNull(term.Tags);
+            Assert.AreEqual(1, term.Tags.Count);
+            Assert.IsNull(term.NTerminalDescriptors);
+            Assert.IsNull(term.CTerminalDescriptors);
+
+            ProFormaTag tag25 = term.Tags[0];
+            Assert.AreEqual(24, tag25.Index);
+            Assert.AreEqual(5, tag25.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Mod, tag25.Descriptors[0].Key);
+            Assert.AreEqual("p-adenosine", tag25.Descriptors[0].Value);
+            Assert.AreEqual(ProFormaKey.Mod, tag25.Descriptors[1].Key);
+            Assert.AreEqual(" N6-(phospho-5'-adenosine)-L-lysine(RESID)", tag25.Descriptors[1].Value);
+            Assert.AreEqual(ProFormaKey.Resid, tag25.Descriptors[2].Key);
+            Assert.AreEqual("AA0227", tag25.Descriptors[2].Value);
+            Assert.AreEqual(ProFormaKey.PsiMod, tag25.Descriptors[3].Key);
+            Assert.AreEqual("MOD:00232", tag25.Descriptors[3].Value);
+            Assert.AreEqual(ProFormaKey.Mod, tag25.Descriptors[4].Key);
+            Assert.AreEqual(" N6AMPLys(PSI-MOD)", tag25.Descriptors[4].Value);
+        }
+
+        [Test]
+        public void BestPractice_iv()
+        {
+            const string proFormaString = "MTLFQLDEKLTA[mass:-37.995001|info:unknown modification]FRNKSMLFQRELRPNEEVTWK";
+            var term = _parser.ParseString(proFormaString);
+
+            Assert.AreEqual("MTLFQLDEKLTAFRNKSMLFQRELRPNEEVTWK", term.Sequence);
+            Assert.IsNotNull(term.Tags);
+            Assert.AreEqual(1, term.Tags.Count);
+            Assert.IsNull(term.NTerminalDescriptors);
+            Assert.IsNull(term.CTerminalDescriptors);
+
+            ProFormaTag tag12 = term.Tags[0];
+            Assert.AreEqual(11, tag12.Index);
+            Assert.AreEqual(2, tag12.Descriptors.Count);
+            Assert.AreEqual(ProFormaKey.Mass, tag12.Descriptors[0].Key); // Unimod
+            Assert.AreEqual("-37.995001", tag12.Descriptors[0].Value);
+            Assert.AreEqual(ProFormaKey.Info, tag12.Descriptors[1].Key); // RESID
+            Assert.AreEqual("unknown modification", tag12.Descriptors[1].Value);
+        }
+
+        [Test]
+        [TestCase("PRO[]TEOFORM")]
+        [TestCase("PRO[mod:Methyl|]TEOFORM")]
+        //[TestCase("PRO[fake:Formaldehyde]TEOFORM")]
         [TestCase("PROTEOFXRM")]
         [TestCase("PROTEOF@RM")]
         [TestCase("proteoform")]
@@ -243,27 +356,6 @@ namespace TestProject1
         [TestCase("----")]
         public void BadInput(string proFormaString)
         {
-            Assert.Throws<ProFormaParseException>(() => _parser.ParseString(proFormaString));
-        }
-
-        [Test]
-        public void EmptyDescriptor()
-        {
-            const string proFormaString = "PRO[]TEOFORM";
-            Assert.Throws<ProFormaParseException>(() => _parser.ParseString(proFormaString));
-        }
-
-        [Test]
-        public void MixedEmptyDescriptor()
-        {
-            const string proFormaString = "PRO[mod:Methyl|]TEOFORM";
-            Assert.Throws<ProFormaParseException>(() => _parser.ParseString(proFormaString));
-        }
-
-        [Test]
-        public void UnsupportedKey()
-        {
-            const string proFormaString = "PRO[xlink:Formaldehyde]TEOFORM";
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString(proFormaString));
         }
     }


### PR DESCRIPTION
Adds some unit tests and relaxes the requirements for tags (from enum to string). **I'm wanting feedback here:** my plan is to relax the key requirements in this step and handle the higher level logic during validation and conversion. For example, a tag of `[fake:123]` would pass this stage and then throw an exception during a conversion to a proteoform. There was also the practical issue of PSI-MOD not working as an enum value. There is also a unit test called `HandleExtraTagSpaces()` that explicitly tests for extra space handling; I'm curious to see what people think. This PR addresses #22 and #27