### PR TITLE
Isotope handling

### DIFF
--- a/src/TopDownProteomics.Benchmarks/MockElementProvider.cs
+++ b/src/TopDownProteomics.Benchmarks/MockElementProvider.cs
@@ -6,6 +6,7 @@ namespace TopDownProteomics.Benchmarks
     public class MockElementProvider : IElementProvider
     {
         private IElement[] _elements;
+        private IElement _carbon13;
 
         public MockElementProvider()
         {
@@ -38,6 +39,11 @@ namespace TopDownProteomics.Benchmarks
                 new Isotope(33.96786690, 0.0425),
                 new Isotope(35.96708076, 0.0001)
             });
+
+            _carbon13 = new Element(6, "13C", new[]
+            {
+                new Isotope(13.0033548378, 1.0)
+            });
         }
 
         public void OverwriteElement(IElement element)
@@ -54,5 +60,7 @@ namespace TopDownProteomics.Benchmarks
         {
             return _elements.Single(x => x?.Symbol == symbol);
         }
+
+        public IElement GetCarbon13() => _carbon13;
     }
 }

--- a/src/TopDownProteomics.Benchmarks/MockElementProvider.cs
+++ b/src/TopDownProteomics.Benchmarks/MockElementProvider.cs
@@ -13,36 +13,49 @@ namespace TopDownProteomics.Benchmarks
             _elements = new IElement[128];
             _elements[1] = new Element(1, "H", new[]
             {
-                new Isotope(1.007825032, 0.999885),
-                new Isotope(2.014101778, 0.000115)
+                new Isotope(1.007825032, 0, 0.999885),
+                new Isotope(2.014101778, 1, 0.000115)
             });
             _elements[6] = new Element(6, "C", new[]
             {
-                new Isotope(12.0, 0.9893),
-                new Isotope(13.0033548378, 0.0107)
+                new Isotope(12.0, 6, 0.9893),
+                new Isotope(13.0033548378, 7, 0.0107)
             });
             _elements[7] = new Element(7, "N", new[]
             {
-                new Isotope(14.0030740052, 0.99632),
-                new Isotope(15.0001088984, 0.00368)
+                new Isotope(14.0030740052, 7, 0.99632),
+                new Isotope(15.0001088984, 8, 0.00368)
             });
             _elements[8] = new Element(8, "O", new[]
             {
-                new Isotope(15.99491463, 0.99757),
-                new Isotope(16.9991312, 0.00038),
-                new Isotope(17.9991603, 0.00205)
+                new Isotope(15.99491463, 8, 0.99757),
+                new Isotope(16.9991312, 9, 0.00038),
+                new Isotope(17.9991603, 10, 0.00205)
+            });
+            _elements[15] = new Element(15, "P", new[]
+            {
+                new Isotope(30.97376163, 16, 1.0000)
             });
             _elements[16] = new Element(16, "S", new[]
             {
-                new Isotope(31.97207100, 0.9499),
-                new Isotope(32.97145876, 0.0075),
-                new Isotope(33.96786690, 0.0425),
-                new Isotope(35.96708076, 0.0001)
+                new Isotope(31.97207100, 16, 0.9499),
+                new Isotope(32.97145876, 17, 0.0075),
+                new Isotope(33.96786690, 18, 0.0425),
+                new Isotope(35.96708076, 20, 0.0001)
+            });
+            _elements[34] = new Element(34, "Se", new[]
+            {
+                new Isotope(73.9224764, 40, 0.0089),
+                new Isotope(75.9192136, 42, 0.0937),
+                new Isotope(76.9199140, 43, 0.0763),
+                new Isotope(77.9173091, 44, 0.2377),
+                new Isotope(79.9165213, 46, 0.4961),
+                new Isotope(81.9166994, 48, 0.0873)
             });
 
             _carbon13 = new Element(6, "13C", new[]
             {
-                new Isotope(13.0033548378, 1.0)
+                new Isotope(13.0033548378, 7, 1.0)
             });
         }
 
@@ -51,12 +64,12 @@ namespace TopDownProteomics.Benchmarks
             _elements[element.AtomicNumber] = element;
         }
 
-        public IElement GetElement(int atomicNumber)
+        public IElement GetElement(int atomicNumber, int? fixedIsotopeNumber = null)
         {
             return _elements[atomicNumber];
         }
 
-        public IElement GetElement(string symbol)
+        public IElement GetElement(string symbol, int? fixedIsotopeNumber = null)
         {
             return _elements.Single(x => x?.Symbol == symbol);
         }

--- a/src/TopDownProteomics/Chemistry/ChemicalFormula.cs
+++ b/src/TopDownProteomics/Chemistry/ChemicalFormula.cs
@@ -14,7 +14,7 @@ namespace TopDownProteomics.Chemistry
         /// <summary>
         /// Initializes a new instance of the <see cref="ChemicalFormula"/> class.
         /// </summary>
-        public ChemicalFormula()
+        private ChemicalFormula()
         {
             _elements = new List<IEntityCardinality<IElement>>();
         }

--- a/src/TopDownProteomics/Chemistry/IChemicalFormula.cs
+++ b/src/TopDownProteomics/Chemistry/IChemicalFormula.cs
@@ -14,12 +14,6 @@ namespace TopDownProteomics.Chemistry
         /// <returns></returns>
         IReadOnlyCollection<IEntityCardinality<IElement>> GetElements();
 
-        ///// <summary>
-        ///// Gets the independent isotopes.
-        ///// </summary>
-        ///// <returns></returns>
-        //IEntityCardinality<IIsotope> GetIndependentIsotopes();
-
         /// <summary>
         /// Adds the specified formula.
         /// </summary>

--- a/src/TopDownProteomics/Chemistry/IElement.cs
+++ b/src/TopDownProteomics/Chemistry/IElement.cs
@@ -3,7 +3,7 @@
 namespace TopDownProteomics.Chemistry
 {
     /// <summary>
-    /// Represents a single chemical element. Elements comprises of multiple
+    /// Represents a single chemical element. Elements are usually comprised of multiple
     /// isotopes, with the element mass being a weighted average of all the
     /// isotopes atomic masses weighted by their natural relative abundance.
     /// </summary>

--- a/src/TopDownProteomics/Chemistry/IElementProvider.cs
+++ b/src/TopDownProteomics/Chemistry/IElementProvider.cs
@@ -18,5 +18,11 @@
         /// <param name="symbol">The symbol.</param>
         /// <returns></returns>
         IElement GetElement(string symbol);
+
+        /// <summary>
+        /// Gets the Carbon 13 isotopic element.
+        /// </summary>
+        /// <returns></returns>
+        IElement GetCarbon13();
     }
 }

--- a/src/TopDownProteomics/Chemistry/IElementProvider.cs
+++ b/src/TopDownProteomics/Chemistry/IElementProvider.cs
@@ -9,20 +9,16 @@
         /// Gets the element by atomic number.
         /// </summary>
         /// <param name="atomicNumber">The atomic number.</param>
+        /// <param name="fixedIsotopeNumber">Get a fixed isotope element with the given number of subatomic particles in the nucleus.</param>
         /// <returns></returns>
-        IElement GetElement(int atomicNumber);
+        IElement GetElement(int atomicNumber, int? fixedIsotopeNumber = null);
 
         /// <summary>
         /// Gets the element by symbol.
         /// </summary>
         /// <param name="symbol">The symbol.</param>
+        /// <param name="fixedIsotopeNumber">Get a fixed isotope element with the given number of subatomic particles in the nucleus.</param>
         /// <returns></returns>
-        IElement GetElement(string symbol);
-
-        /// <summary>
-        /// Gets the Carbon 13 isotopic element.
-        /// </summary>
-        /// <returns></returns>
-        IElement GetCarbon13();
+        IElement GetElement(string symbol, int? fixedIsotopeNumber = null);
     }
 }

--- a/src/TopDownProteomics/Chemistry/IIsotope.cs
+++ b/src/TopDownProteomics/Chemistry/IIsotope.cs
@@ -12,6 +12,11 @@
         double AtomicMass { get; }
 
         /// <summary>
+        /// Gets the number of neutrons present in the atom's nucleus.
+        /// </summary>
+        int NeutronCount { get; }
+
+        /// <summary>
         /// The occurance of this isotope relative to others from a given element.
         /// </summary>
         /// <value>

--- a/src/TopDownProteomics/Chemistry/InMemoryElementProvider.cs
+++ b/src/TopDownProteomics/Chemistry/InMemoryElementProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace TopDownProteomics.Chemistry
@@ -42,14 +43,38 @@ namespace TopDownProteomics.Chemistry
         /// Gets the element by atomic number.
         /// </summary>
         /// <param name="atomicNumber">The atomic number.</param>
+        /// <param name="fixedIsotopeNumber">Get a fixed isotope element with the given number of subatomic particles in the nucleus.</param>
         /// <returns></returns>
-        public IElement GetElement(int atomicNumber) => _by_atomic_number[atomicNumber];
+        public IElement GetElement(int atomicNumber, int? fixedIsotopeNumber = null)
+        {
+            if (!fixedIsotopeNumber.HasValue)
+                return _by_atomic_number[atomicNumber];
+
+            return this.GetFixedIsotopeElement(_by_atomic_number[atomicNumber], fixedIsotopeNumber.Value);
+        }
 
         /// <summary>
         /// Gets the element by symbol.
         /// </summary>
         /// <param name="symbol">The symbol.</param>
+        /// <param name="fixedIsotopeNumber">Get a fixed isotope element with the given number of subatomic particles in the nucleus.</param>
         /// <returns></returns>
-        public IElement GetElement(string symbol) => _by_symbol[symbol];
+        public IElement GetElement(string symbol, int? fixedIsotopeNumber = null)
+        {
+            if (!fixedIsotopeNumber.HasValue)
+                return _by_symbol[symbol];
+
+            return this.GetFixedIsotopeElement(_by_symbol[symbol], fixedIsotopeNumber.Value);
+        }
+
+        private IElement GetFixedIsotopeElement(IElement element, int fixedIsotopeNumber)
+        {
+            IIsotope oldIsotope = element.Isotopes
+                .Single(x => x.NeutronCount == fixedIsotopeNumber - element.AtomicNumber);
+            IIsotope newIsotope = new Isotope(element.AtomicNumber, oldIsotope.NeutronCount, 1.0);
+
+            return new Element(element.AtomicNumber, element.Symbol,
+                new ReadOnlyCollection<IIsotope>(new[] { newIsotope }));
+        }
     }
 }

--- a/src/TopDownProteomics/Chemistry/Isotope.cs
+++ b/src/TopDownProteomics/Chemistry/Isotope.cs
@@ -10,10 +10,12 @@
         /// Initializes a new instance of the <see cref="Isotope"/> class.
         /// </summary>
         /// <param name="atomicMass">The atomic mass.</param>
+        /// <param name="neutronCount">The neutron count.</param>
         /// <param name="relativeAbundance">The relative abundance.</param>
-        public Isotope(double atomicMass, double relativeAbundance)
+        public Isotope(double atomicMass, int neutronCount, double relativeAbundance)
         {
             this.AtomicMass = atomicMass;
+            this.NeutronCount = neutronCount;
             this.RelativeAbundance = relativeAbundance;
         }
 
@@ -22,6 +24,11 @@
         /// </summary>
         public double AtomicMass { get; }
 
+        /// <summary>
+        /// Gets the number of neutrons present in the atom's nucleus.
+        /// </summary>
+        public int NeutronCount { get; }
+        
         /// <summary>
         /// The occurance of this isotope relative to others from a given element.
         /// </summary>

--- a/src/TopDownProteomics/Chemistry/NistElementParser.cs
+++ b/src/TopDownProteomics/Chemistry/NistElementParser.cs
@@ -20,6 +20,7 @@ namespace TopDownProteomics.Chemistry
             List<IElement> elements = new List<IElement>();
             int currentAtomNumber = -1;
             string currentSymbol = null;
+            int currentMassNumber = -1;
             List<IIsotope> currentIsotopes = null;
             double currentRelativeAtomicMass = 0.0;
             double currentIsotopicComposition = 0.0;
@@ -44,6 +45,10 @@ namespace TopDownProteomics.Chemistry
                 else if (lines[i].StartsWith("Atomic Symbol = ") && currentSymbol == null)
                 {
                     currentSymbol = lines[i].Substring(lines[i].LastIndexOf('=') + 1).Trim();
+                }
+                else if (lines[i].StartsWith("Mass Number = "))
+                {
+                    currentMassNumber = Convert.ToInt32(lines[i].Substring(lines[i].LastIndexOf('=') + 1).Trim());
                 }
                 else if (lines[i].StartsWith("Relative Atomic Mass = "))
                 {
@@ -71,7 +76,7 @@ namespace TopDownProteomics.Chemistry
                     if (currentIsotopes == null)
                         currentIsotopes = new List<IIsotope>();
 
-                    currentIsotopes.Add(new Isotope(currentRelativeAtomicMass, currentIsotopicComposition));
+                    currentIsotopes.Add(new Isotope(currentRelativeAtomicMass, currentMassNumber - currentAtomNumber, currentIsotopicComposition));
                 }
             }
 

--- a/src/TopDownProteomics/Chemistry/NistElementParser.cs
+++ b/src/TopDownProteomics/Chemistry/NistElementParser.cs
@@ -17,7 +17,7 @@ namespace TopDownProteomics.Chemistry
         public IList<IElement> ParseFile(string filePath)
         {
             var lines = File.ReadAllLines(filePath);
-            List<IElement> elements = new List<IElement>();
+            var elements = new List<IElement>();
             int currentAtomNumber = -1;
             string currentSymbol = null;
             int currentMassNumber = -1;

--- a/src/TopDownProteomics/Chemistry/Unimod/UnimodComposition.cs
+++ b/src/TopDownProteomics/Chemistry/Unimod/UnimodComposition.cs
@@ -42,7 +42,7 @@ namespace TopDownProteomics.Chemistry.Unimod
 
                 if (symbol.Contains("("))
                 {
-                    int startIndex = atoms[0].IndexOf("(");
+                    int startIndex = atoms[i].IndexOf("(");
                     symbol = atoms[i].Substring(0, startIndex);
                     count = Convert.ToInt32(atoms[i].Substring(startIndex + 1, atoms[i].Length - startIndex - 2));
                 }

--- a/src/TopDownProteomics/Chemistry/Unimod/UnimodHardCodedAtomProvider.cs
+++ b/src/TopDownProteomics/Chemistry/Unimod/UnimodHardCodedAtomProvider.cs
@@ -29,34 +29,10 @@ namespace TopDownProteomics.Chemistry.Unimod
             var o = elementProvider.GetElement(8);
             var s = elementProvider.GetElement(16);
 
-            atoms.Add("13C", new UnimodCompositionAtom("13C", "Carbon 13", new[]
-            {
-                new EntityCardinality<IElement>(new Element(c.AtomicNumber, c.Symbol, new[]
-                {
-                    c.Isotopes.FirstWithMax(x => x.AtomicMass)
-                }), 1)
-            }));
-            atoms.Add("15N", new UnimodCompositionAtom("15N", "Nitrogen 15", new[]
-            {
-                new EntityCardinality<IElement>(new Element(n.AtomicNumber, n.Symbol, new[]
-                {
-                    n.Isotopes.FirstWithMax(x => x.AtomicMass)
-                }), 1)
-            }));
-            atoms.Add("18O", new UnimodCompositionAtom("18O", "Oxygen 18", new[]
-            {
-                new EntityCardinality<IElement>(new Element(o.AtomicNumber, o.Symbol, new[]
-                {
-                    o.Isotopes.FirstWithMax(x => x.AtomicMass)
-                }), 1)
-            }));
-            atoms.Add("2H", new UnimodCompositionAtom("2H", "Deuterium", new[]
-                        {
-                new EntityCardinality<IElement>(new Element(h.AtomicNumber, h.Symbol, new[]
-                {
-                    h.Isotopes.FirstWithMax(x => x.AtomicMass)
-                }), 1)
-            }));
+            this.AddElement(atoms, elementProvider, "13C", "Carbon 13", "C", 13);
+            this.AddElement(atoms, elementProvider, "15N", "Nitrogen 15", "N", 15);
+            this.AddElement(atoms, elementProvider, "18O", "Oxygen 18", "O", 18);
+            this.AddElement(atoms, elementProvider, "2H", "Deuterium", "H", 2);
 
             // Never used
             //atoms.Add("Ac", new UnimodCompositionAtom("Ac", "Acetate", new[]
@@ -220,9 +196,20 @@ namespace TopDownProteomics.Chemistry.Unimod
             return atoms;
         }
 
-        private void AddElement(Dictionary<string, UnimodCompositionAtom> atoms, IElementProvider elementProvider, string symbol, string name)
+        private void AddElement(Dictionary<string, UnimodCompositionAtom> atoms, IElementProvider elementProvider,
+            string symbol, string name)
         {
             IElement element = elementProvider.GetElement(symbol);
+            atoms.Add(symbol, new UnimodCompositionAtom(symbol, name, new[]
+            {
+                new EntityCardinality<IElement>(element, 1)
+            }));
+        }
+
+        private void AddElement(Dictionary<string, UnimodCompositionAtom> atoms, IElementProvider elementProvider,
+            string symbol, string name, string elementSymbol, int? fixedIsotopeNumber = null)
+        {
+            IElement element = elementProvider.GetElement(elementSymbol, fixedIsotopeNumber);
             atoms.Add(symbol, new UnimodCompositionAtom(symbol, name, new[]
             {
                 new EntityCardinality<IElement>(element, 1)

--- a/tests/TopDownProteomics.Tests/ChemicalFormulaTests.cs
+++ b/tests/TopDownProteomics.Tests/ChemicalFormulaTests.cs
@@ -36,11 +36,11 @@ namespace TopDownProteomics.Tests.ProForma
             var provider = new MockElementProvider();
             provider.OverwriteElement(new Element(1, "H", new[]
             {
-                new Isotope(1, 1.0)
+                new Isotope(1, 0, 1.0)
             }));
             provider.OverwriteElement(new Element(8, "O", new[]
             {
-                new Isotope(16, 1.0)
+                new Isotope(16, 8, 1.0)
             }));
 
             var formula = ChemicalFormula.Water(provider);
@@ -52,8 +52,8 @@ namespace TopDownProteomics.Tests.ProForma
             // Switch to 75/25
             provider.OverwriteElement(new Element(8, "O", new[]
             {
-                new Isotope(16, 0.75),
-                new Isotope(17, 0.25)
+                new Isotope(16, 8, 0.75),
+                new Isotope(17, 9, 0.25)
             }));
 
             formula = ChemicalFormula.Water(provider);
@@ -79,6 +79,33 @@ namespace TopDownProteomics.Tests.ProForma
 
             Assert.AreEqual(formula, formula2);
             Assert.AreNotEqual(formula, formula3);
+        }
+
+        [Test]
+        public void Carbon13Test()
+        {
+            IElementProvider provider = new MockElementProvider();
+            IElement c = provider.GetElement("C");
+            IElement c13 = provider.GetElement("C", 13);
+
+            var formula = new ChemicalFormula(new[]
+            {
+                new EntityCardinality<IElement>(c, 1),
+                new EntityCardinality<IElement>(c13, 1),
+            });
+
+            var elements = formula.GetElements();
+
+            Assert.AreEqual(2, elements.Count);
+
+            // Check masses
+            Assert.AreEqual(c.Isotopes.FirstWithMax(x => x.RelativeAbundance).AtomicMass
+                + c13.Isotopes.FirstWithMax(x => x.RelativeAbundance).AtomicMass,
+                formula.GetMass(MassType.Monoisotopic));
+            Assert.AreEqual(c.Isotopes.Sum(x => x.AtomicMass * x.RelativeAbundance)
+                + c13.Isotopes.Sum(x => x.AtomicMass * x.RelativeAbundance),
+                formula.GetMass(MassType.Average));
+            Assert.AreEqual(c13.GetMass(MassType.Monoisotopic), c13.GetMass(MassType.Average));
         }
     }
 }

--- a/tests/TopDownProteomics.Tests/MockElementProvider.cs
+++ b/tests/TopDownProteomics.Tests/MockElementProvider.cs
@@ -6,6 +6,7 @@ namespace TopDownProteomics.Tests
     public class MockElementProvider : IElementProvider
     {
         private IElement[] _elements;
+        private IElement _carbon13;
 
         public MockElementProvider()
         {
@@ -51,6 +52,11 @@ namespace TopDownProteomics.Tests
                 new Isotope(79.9165213, 0.4961),
                 new Isotope(81.9166994, 0.0873)
             });
+
+            _carbon13 = new Element(6, "13C", new[]
+            {
+                new Isotope(13.0033548378, 1.0)
+            });
         }
 
         public void OverwriteElement(IElement element)
@@ -67,5 +73,7 @@ namespace TopDownProteomics.Tests
         {
             return _elements.Single(x => x?.Symbol == symbol);
         }
+
+        public IElement GetCarbon13() => _carbon13;
     }
 }

--- a/tests/TopDownProteomics.Tests/MockElementProvider.cs
+++ b/tests/TopDownProteomics.Tests/MockElementProvider.cs
@@ -13,49 +13,49 @@ namespace TopDownProteomics.Tests
             _elements = new IElement[128];
             _elements[1] = new Element(1, "H", new[]
             {
-                new Isotope(1.007825032, 0.999885),
-                new Isotope(2.014101778, 0.000115)
+                new Isotope(1.007825032, 0, 0.999885),
+                new Isotope(2.014101778, 1, 0.000115)
             });
             _elements[6] = new Element(6, "C", new[]
             {
-                new Isotope(12.0, 0.9893),
-                new Isotope(13.0033548378, 0.0107)
+                new Isotope(12.0, 6, 0.9893),
+                new Isotope(13.0033548378, 7, 0.0107)
             });
             _elements[7] = new Element(7, "N", new[]
             {
-                new Isotope(14.0030740052, 0.99632),
-                new Isotope(15.0001088984, 0.00368)
+                new Isotope(14.0030740052, 7, 0.99632),
+                new Isotope(15.0001088984, 8, 0.00368)
             });
             _elements[8] = new Element(8, "O", new[]
             {
-                new Isotope(15.99491463, 0.99757),
-                new Isotope(16.9991312, 0.00038),
-                new Isotope(17.9991603, 0.00205)
+                new Isotope(15.99491463, 8, 0.99757),
+                new Isotope(16.9991312, 9, 0.00038),
+                new Isotope(17.9991603, 10, 0.00205)
             });
             _elements[15] = new Element(15, "P", new[] 
             {
-                new Isotope(30.97376163, 1.0000)
+                new Isotope(30.97376163, 16, 1.0000)
             });
             _elements[16] = new Element(16, "S", new[]
             {
-                new Isotope(31.97207100, 0.9499),
-                new Isotope(32.97145876, 0.0075),
-                new Isotope(33.96786690, 0.0425),
-                new Isotope(35.96708076, 0.0001)
+                new Isotope(31.97207100, 16, 0.9499),
+                new Isotope(32.97145876, 17, 0.0075),
+                new Isotope(33.96786690, 18, 0.0425),
+                new Isotope(35.96708076, 20, 0.0001)
             });
             _elements[34] = new Element(34, "Se", new[]
             {
-                new Isotope(73.9224764, 0.0089),
-                new Isotope(75.9192136, 0.0937),
-                new Isotope(76.9199140, 0.0763),
-                new Isotope(77.9173091, 0.2377),
-                new Isotope(79.9165213, 0.4961),
-                new Isotope(81.9166994, 0.0873)
+                new Isotope(73.9224764, 40, 0.0089),
+                new Isotope(75.9192136, 42, 0.0937),
+                new Isotope(76.9199140, 43, 0.0763),
+                new Isotope(77.9173091, 44, 0.2377),
+                new Isotope(79.9165213, 46, 0.4961),
+                new Isotope(81.9166994, 48, 0.0873)
             });
 
             _carbon13 = new Element(6, "13C", new[]
             {
-                new Isotope(13.0033548378, 1.0)
+                new Isotope(13.0033548378, 7, 1.0)
             });
         }
 
@@ -64,16 +64,20 @@ namespace TopDownProteomics.Tests
             _elements[element.AtomicNumber] = element;
         }
 
-        public IElement GetElement(int atomicNumber)
+        public IElement GetElement(int atomicNumber, int? fixedIsotopeNumber = null)
         {
+            if (atomicNumber == 6 && fixedIsotopeNumber == 13)
+                return _carbon13;
+
             return _elements[atomicNumber];
         }
 
-        public IElement GetElement(string symbol)
+        public IElement GetElement(string symbol, int? fixedIsotopeNumber = null)
         {
+            if (symbol == "C" && fixedIsotopeNumber == 13)
+                return _carbon13;
+
             return _elements.Single(x => x?.Symbol == symbol);
         }
-
-        public IElement GetCarbon13() => _carbon13;
     }
 }

--- a/tests/TopDownProteomics.Tests/NistElementParserTest.cs
+++ b/tests/TopDownProteomics.Tests/NistElementParserTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.IO;
 using System.Linq;
 using TopDownProteomics.Chemistry;
@@ -11,7 +12,7 @@ namespace TopDownProteomics.Tests
         [Test]
         public void LoadEntireFile()
         {
-            NistElementParser parser = new NistElementParser();
+            var parser = new NistElementParser();
             var elements = parser.ParseFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "elements.dat"));
 
             Assert.IsNotNull(elements);
@@ -26,6 +27,12 @@ namespace TopDownProteomics.Tests
             var h2 = h.Isotopes.Single(x => x.AtomicMass > 2);
             Assert.AreEqual(2.01410177812, h2.AtomicMass);
             Assert.AreEqual(0.000115, h2.RelativeAbundance);
+
+            var c = elements.Single(x => x.AtomicNumber == 6);
+            var c12 = c.Isotopes.Single(x => Math.Round(x.AtomicMass) == 12);
+            Assert.AreEqual(6, c12.NeutronCount);
+            var c13 = c.Isotopes.Single(x => Math.Round(x.AtomicMass) == 13);
+            Assert.AreEqual(7, c13.NeutronCount);
 
             var xe = elements.Single(x => x.AtomicNumber == 54);
             Assert.AreEqual("Xe", xe.Symbol);

--- a/tests/TopDownProteomics.Tests/UnimodCompositionTests.cs
+++ b/tests/TopDownProteomics.Tests/UnimodCompositionTests.cs
@@ -145,7 +145,7 @@ namespace TopDownProteomics.Tests
                 });
 
                 _carbon13 = new UnimodCompositionAtom("13C", "Carbon 13", new[] {
-                    new EntityCardinality<IElement>(elementProvider.GetCarbon13(), 1) });
+                    new EntityCardinality<IElement>(elementProvider.GetElement(6, 13), 1) });
             }
 
             public UnimodCompositionAtom GetUnimodCompositionAtom(string symbol)


### PR DESCRIPTION
Handles isotopes in chemical formulas (actually at the element provider level). See #56. I chose a 3rd path, allowing elements to be either "natural" or "fixed isotope" (although there is nothing on the IElement interface to indicate this presently). When getting an element from a provider, you can optionally ask for a fixed isotope version.