### PR TITLE
Proteoform Hash Changes

### DIFF
--- a/src/TopDownProteomics/ProForma/Validation/BrnoModificationLookup.cs
+++ b/src/TopDownProteomics/ProForma/Validation/BrnoModificationLookup.cs
@@ -11,7 +11,6 @@ namespace TopDownProteomics.ProForma.Validation
     /// <seealso cref="IProteoformModificationLookup" />
     public class BrnoModificationLookup : IProteoformModificationLookup
     {
-        IElementProvider elementProvider;
         BrnoModification[] _modifications;
 
         /// <summary>
@@ -20,7 +19,6 @@ namespace TopDownProteomics.ProForma.Validation
         /// <param name="elementProvider">The element provider.</param>
         public BrnoModificationLookup(IElementProvider elementProvider)
         {
-            this.elementProvider = elementProvider;
             _modifications = this.CreateModificationArray(elementProvider);
         }
 
@@ -107,7 +105,7 @@ namespace TopDownProteomics.ProForma.Validation
             return mods;
         }
 
-        private class BrnoModification : IProFormaProteoformModification
+        private class BrnoModification : IProFormaProteoformModification, IIdentifiable, IHasChemicalFormula
         {
             public BrnoModification(string abbreviation, IReadOnlyCollection<IEntityCardinality<IElement>> elements)
             {
@@ -118,12 +116,18 @@ namespace TopDownProteomics.ProForma.Validation
             private IReadOnlyCollection<IEntityCardinality<IElement>> _elements;
             string Abbreviation { get; }
 
+            public string Id => this.Abbreviation;
+
+            public string Name => this.Abbreviation;
+
             public IChemicalFormula GetChemicalFormula() => new ChemicalFormula(_elements);
 
             public ProFormaDescriptor GetProFormaDescriptor()
             {
                 return new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.None, this.Abbreviation);
             }
+
+            public double GetMass(MassType massType) => this.GetChemicalFormula().GetMass(massType);
         }
     }
 }

--- a/src/TopDownProteomics/ProForma/Validation/FormulaLookup.cs
+++ b/src/TopDownProteomics/ProForma/Validation/FormulaLookup.cs
@@ -36,11 +36,11 @@ namespace TopDownProteomics.ProForma.Validation
             }
             else
             {
-                throw new ProteoformModificationLookupException($"Could not parse formula string for descriptor {descriptor.ToString()}");
+                throw new ProteoformModificationLookupException($"Could not parse formula string for descriptor {descriptor}");
             }
         }
 
-        private class FormulaModification : IProteoformModification
+        private class FormulaModification : IProteoformModification, IHasChemicalFormula
         {
             private IChemicalFormula _chemicalFormula;
 
@@ -53,6 +53,8 @@ namespace TopDownProteomics.ProForma.Validation
             {
                 return this._chemicalFormula;
             }
+
+            public double GetMass(MassType massType) => _chemicalFormula.GetMass(massType);
         }
     }
 }

--- a/src/TopDownProteomics/ProForma/Validation/MassLookup.cs
+++ b/src/TopDownProteomics/ProForma/Validation/MassLookup.cs
@@ -1,0 +1,49 @@
+﻿using TopDownProteomics.Chemistry;
+using TopDownProteomics.Proteomics;
+
+namespace TopDownProteomics.ProForma.Validation
+{
+    /// <summary>Lookup for modifications given by mass value.</summary>
+    /// <seealso cref="IProteoformModificationLookup" />
+    public class MassLookup : IProteoformModificationLookup
+    {
+        /// <summary>Initializes a new instance of the <see cref="MassLookup"/> class.</summary>
+        public MassLookup() { }
+
+        /// <summary>Determines whether this instance [can handle descriptor] the specified descriptor.</summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <returns>
+        ///   <c>true</c> if this instance [can handle descriptor] the specified descriptor; otherwise, <c>false</c>.</returns>
+        public bool CanHandleDescriptor(ProFormaDescriptor descriptor)
+        {
+            return descriptor.Key == ProFormaKey.Mass;
+        }
+
+        /// <summary>Gets the modification.</summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <returns></returns>
+        public IProteoformModification? GetModification(ProFormaDescriptor descriptor)
+        {
+            if (double.TryParse(descriptor.Value, out double mass))
+            {
+                return new MassModification(mass);
+            }
+            else
+            {
+                throw new ProteoformModificationLookupException($"Could not parse mass string for descriptor {descriptor}");
+            }
+        }
+
+        private class MassModification : IProteoformModification
+        {
+            private readonly double _mass;
+
+            public MassModification(double mass)
+            {
+                _mass = mass;
+            }
+
+            public double GetMass(MassType massType) => _mass;
+        }
+    }
+}

--- a/src/TopDownProteomics/ProForma/Validation/ModificationLookupBase.cs
+++ b/src/TopDownProteomics/ProForma/Validation/ModificationLookupBase.cs
@@ -71,9 +71,7 @@ namespace TopDownProteomics.ProForma.Validation
                 (descriptor.Key == ProFormaKey.Name && descriptor.EvidenceType == ProFormaEvidenceType.None);
         }
 
-        /// <summary>
-        /// The ProForma key.
-        /// </summary>
+        /// <summary>The ProForma key.</summary>
         protected abstract ProFormaEvidenceType EvidenceType { get; }
 
         /// <summary>
@@ -90,8 +88,6 @@ namespace TopDownProteomics.ProForma.Validation
         ///   <c>true</c> if this instance is default modification type; otherwise, <c>false</c>.
         /// </value>
         protected virtual bool IsDefaultModificationType => false;
-
-        //private string GetModNameDatabaseTag() => $"({this.Key})";
 
         /// <summary>
         /// Gets the modification.
@@ -136,7 +132,7 @@ namespace TopDownProteomics.ProForma.Validation
             throw new ProteoformModificationLookupException($"Couldn't handle value for descriptor {descriptor}.");
         }
 
-        private class ModificationWrapper : IProFormaProteoformModification
+        private class ModificationWrapper : IProFormaProteoformModification, IIdentifiable, IHasChemicalFormula
         {
             private IChemicalFormula _chemicalFormula;
 
@@ -148,12 +144,18 @@ namespace TopDownProteomics.ProForma.Validation
 
             public T Modification { get; }
 
+            public string Id => this.Modification.Id;
+
+            public string Name => this.Modification.Name;
+
             public IChemicalFormula GetChemicalFormula() => _chemicalFormula;
 
             public ProFormaDescriptor GetProFormaDescriptor()
             {
                 throw new NotImplementedException();
             }
+
+            public double GetMass(MassType massType) => _chemicalFormula.GetMass(massType);
         }
     }
 }

--- a/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
+++ b/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
@@ -9,21 +9,37 @@ using TopDownProteomics.Proteomics;
 namespace TopDownProteomics.ProteoformHash
 {
     /// <summary>Creates a chemical proteoform hash from a proteoform group.</summary>
+    /// <remarks>
+    /// The basic idea is to handle 4 different levels of "hierarchy" and do some mapping.
+    ///  1. Structural based modifications (e.g. symmetric dimethylation) -> map these to their proper term (usually PSI-MOD)
+    ///  2. Named modifications (e.g. acetylation)                        -> map these to their proper term (usually PSI-MOD)
+    ///  3. Chemical formulas                                             -> standardize expression (don't map to term)
+    ///  4. Mass Differences                                              -> remove leading and trailing zeros (don't map to term)
+    /// 
+    /// One must also standardize the way group and unlocalized notations are written.
+    /// Lastly, INFO tags should be stripped.
+    /// </remarks>
     public class ChemicalProteoformHashGenerator : IChemicalProteoformHashGenerator
     {
         private ProFormaParser _proFormaParser;
         private ProteoformGroupFactory _proteoformGroupFactory;
         private IProteoformModificationLookup _proteoformModificationLookup;
+        private IAccessionMapper _mapper;
 
-        /// <summary>Initializes a new instance of the <see cref="ChemicalProteoformHashGenerator"/> class.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChemicalProteoformHashGenerator" /> class.
+        /// </summary>
         /// <param name="proFormaParser">The proForma parser.</param>
         /// <param name="proteoformGroupFactory">The proteoform group factory.</param>
         /// <param name="proteoformModificationLookup">The proteoform modification lookup.</param>
-        public ChemicalProteoformHashGenerator(ProFormaParser proFormaParser, ProteoformGroupFactory proteoformGroupFactory, IProteoformModificationLookup proteoformModificationLookup)
+        /// <param name="mapper">The mapper.</param>
+        public ChemicalProteoformHashGenerator(ProFormaParser proFormaParser, ProteoformGroupFactory proteoformGroupFactory,
+            IProteoformModificationLookup proteoformModificationLookup, IAccessionMapper mapper)
         {
             _proFormaParser = proFormaParser;
             _proteoformGroupFactory = proteoformGroupFactory;
             _proteoformModificationLookup = proteoformModificationLookup;
+            _mapper = mapper;
         }
 
         /// <summary>Generates a chemical proteoform hash for the specified proteoform.</summary>
@@ -31,20 +47,31 @@ namespace TopDownProteomics.ProteoformHash
         /// <returns></returns>
         public IChemicalProteoformHash Generate(string proForma)
         {
+            // Parse string into term
             ProFormaTerm originalProFormaTerm = this._proFormaParser.ParseString(proForma);
-            IProteoformGroup proteoformGroup = this._proteoformGroupFactory.CreateProteoformGroup(originalProFormaTerm, this._proteoformModificationLookup);
 
-            if (proteoformGroup == null)
+            // Check to see if this is only a sequence
+            if (originalProFormaTerm.NTerminalDescriptors == null &&
+                originalProFormaTerm.CTerminalDescriptors == null &&
+                originalProFormaTerm.Tags == null &&
+                originalProFormaTerm.GlobalModifications == null &&
+                originalProFormaTerm.LabileDescriptors == null &&
+                originalProFormaTerm.TagGroups == null &&
+                originalProFormaTerm.UnlocalizedTags == null)
             {
-                throw new ArgumentNullException(nameof(proteoformGroup));
+                return new ChemicalProteoformHash(originalProFormaTerm.Sequence);
             }
 
+            // Create proteoform group (flattens all features into Ids)
+            IProteoformGroup proteoformGroup = this._proteoformGroupFactory.CreateProteoformGroup(originalProFormaTerm,
+                this._proteoformModificationLookup);
+
             ProFormaDescriptor? nTermDescriptor =
-                this.GetFormulaDescriptor(proteoformGroup.NTerminalModification);
+                this.CreateDescriptor(proteoformGroup.NTerminalModification);
             IList<ProFormaDescriptor>? nTermDescriptors = nTermDescriptor == null ? null : new[] { nTermDescriptor };
 
             ProFormaDescriptor? cTermDescriptor =
-                this.GetFormulaDescriptor(proteoformGroup.CTerminalModification);
+                this.CreateDescriptor(proteoformGroup.CTerminalModification);
             IList<ProFormaDescriptor>? cTermDescriptors = cTermDescriptor == null ? null : new[] { cTermDescriptor };
 
             IList<ProFormaTag>? tags = null;
@@ -53,8 +80,8 @@ namespace TopDownProteomics.ProteoformHash
                 tags = new List<ProFormaTag>();
                 foreach (IProteoformModificationWithIndex proteoformModificationWithIndex in proteoformGroup.Modifications)
                 {
-                    ProFormaDescriptor? descriptor = this.GetFormulaDescriptor(proteoformModificationWithIndex);
-                    
+                    ProFormaDescriptor? descriptor = this.CreateDescriptor(proteoformModificationWithIndex.Modification);
+
                     if (descriptor != null)
                         tags.Add(new ProFormaTag(proteoformModificationWithIndex.ZeroBasedIndex, new[] { descriptor }));
                 }
@@ -73,11 +100,35 @@ namespace TopDownProteomics.ProteoformHash
             throw new Exception("Cannot get amino acid sequence for the proteoform group.");
         }
 
-        private ProFormaDescriptor? GetFormulaDescriptor(IProteoformModification? proteoformModification)
+        private ProFormaDescriptor? CreateDescriptor(IProteoformModification? proteoformModification)
         {
-            return proteoformModification == null
-                    ? null
-                    : new ProFormaDescriptor(ProFormaKey.Formula, ChemistryUtility.GetChemicalFormulaString(proteoformModification.GetChemicalFormula()));
+            // TODO: Standardize group notations and unlocalized cardinality
+
+            return proteoformModification switch
+            {
+                null => null,
+                IIdentifiable ontologyMod => this.GetOntologyDescriptor(ontologyMod),
+                IHasChemicalFormula formulaMod => this.GetFormulaDescriptor(formulaMod),
+                _ => new ProFormaDescriptor(ProFormaKey.Mass, this.GetMassString(proteoformModification.GetMass(MassType.Monoisotopic)))
+            };
+        }
+
+        private ProFormaDescriptor GetOntologyDescriptor(IIdentifiable ontologyMod)
+        {
+            var (evidence, accession) = _mapper.MapAccession(ontologyMod.Id);
+
+            return new ProFormaDescriptor(ProFormaKey.Identifier, evidence, accession);
+        }
+        private ProFormaDescriptor GetFormulaDescriptor(IHasChemicalFormula formulaMod)
+        {
+            return new ProFormaDescriptor(ProFormaKey.Formula, ChemistryUtility.GetChemicalFormulaString(formulaMod.GetChemicalFormula()));
+        }
+        private string GetMassString(double mass)
+        {
+            if (mass >= 0.0)
+                return $"+{mass}";
+
+            return mass.ToString();
         }
 
         private class ChemicalProteoformHash : IChemicalProteoformHash

--- a/src/TopDownProteomics/ProteoformHash/IAccessionMapper.cs
+++ b/src/TopDownProteomics/ProteoformHash/IAccessionMapper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using TopDownProteomics.ProForma;
+
+namespace TopDownProteomics.ProteoformHash
+{
+    /// <summary>Maps a modification accession to a PSI-MOD accession.</summary>
+    public interface IAccessionMapper
+    {
+        /// <summary>
+        /// Maps the given accession to a PSI-MOD accession.
+        /// </summary>
+        /// <param name="accession">The accession.</param>
+        /// <returns></returns>
+        public Tuple<ProFormaEvidenceType, string> MapAccession(string accession);
+    }
+}

--- a/src/TopDownProteomics/ProteoformHash/RelayAccessionMapper.cs
+++ b/src/TopDownProteomics/ProteoformHash/RelayAccessionMapper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using TopDownProteomics.ProForma;
+
+namespace TopDownProteomics.ProteoformHash
+{
+    /// <summary>
+    /// Maps a modification accession to a PSI-MOD accession.
+    /// </summary>
+    /// <seealso cref="IAccessionMapper" />
+    public class RelayAccessionMapper : IAccessionMapper
+    {
+        private Func<string, Tuple<ProFormaEvidenceType, string>> _func;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelayAccessionMapper"/> class.
+        /// </summary>
+        /// <param name="func">The function.</param>
+        public RelayAccessionMapper(Func<string, Tuple<ProFormaEvidenceType, string>> func)
+        {
+            _func = func;
+        }
+
+        /// <summary>
+        /// Maps the given accession to a PSI-MOD accession.
+        /// </summary>
+        /// <param name="accession">The accession.</param>
+        /// <returns></returns>
+        public Tuple<ProFormaEvidenceType, string> MapAccession(string accession)
+        {
+            return _func(accession);
+        }
+    }
+}

--- a/src/TopDownProteomics/Proteomics/IProteoformGroup.cs
+++ b/src/TopDownProteomics/Proteomics/IProteoformGroup.cs
@@ -5,18 +5,16 @@ using TopDownProteomics.Chemistry;
 
 namespace TopDownProteomics.Proteomics
 {
-    /// <summary>
-    /// An observed proteoform with a sequence and modifications with possible ambiguity.
-    /// </summary>
+    /// <summary>An observed proteoform with a sequence and modifications with possible ambiguity.</summary>
     public interface IProteoformGroup : IHasMass
     {
         /// <summary>The amino acid residues.</summary>
         IReadOnlyList<IResidue> Residues { get; }
 
-        /// <summary>The N terminal modification on this proteoform.</summary>
+        /// <summary>The N-terminal modification on this proteoform.</summary>
         IProteoformModification? NTerminalModification { get; }
         
-        /// <summary>The C terminal modification on this proteoform.</summary>
+        /// <summary>The C-terminal modification on this proteoform.</summary>
         IProteoformModification? CTerminalModification { get; }
 
         /// <summary>The modifications on this proteoform.</summary>

--- a/src/TopDownProteomics/Proteomics/IProteoformModification.cs
+++ b/src/TopDownProteomics/Proteomics/IProteoformModification.cs
@@ -2,10 +2,8 @@
 
 namespace TopDownProteomics.Proteomics
 {
-    /// <summary>
-    /// Modification on a chemical proteoform.
-    /// </summary>
-    public interface IProteoformModification : IHasChemicalFormula
+    /// <summary>Modification on a chemical proteoform.</summary>
+    public interface IProteoformModification : IHasMass
     {
 
     }

--- a/src/TopDownProteomics/Proteomics/IProteoformModificationWithIndex.cs
+++ b/src/TopDownProteomics/Proteomics/IProteoformModificationWithIndex.cs
@@ -1,14 +1,13 @@
 ﻿namespace TopDownProteomics.Proteomics
 {
-    /// <summary>
-    /// Modification on a chemical proteoform that has a zero-based index.
-    /// </summary>
+    /// <summary>Modification on a chemical proteoform that has a zero-based index.</summary>
     /// <seealso cref="IProteoformModification" />
-    public interface IProteoformModificationWithIndex : IProteoformModification
+    public interface IProteoformModificationWithIndex
     {
-        /// <summary>
-        /// Gets the zero-based index in the sequence.
-        /// </summary>
+        /// <summary>The zero-based index in the sequence.</summary>
         int ZeroBasedIndex { get; }
+
+        /// <summary>The modification.</summary>
+        IProteoformModification Modification { get; }
     }
 }

--- a/src/TopDownProteomics/Proteomics/ProteoformGroupFactory.cs
+++ b/src/TopDownProteomics/Proteomics/ProteoformGroupFactory.cs
@@ -96,7 +96,7 @@ namespace TopDownProteomics.Proteomics
                     }
                     else
                     {
-                        throw new ProteoformGroupCreateException($"Couldn't handle descriptor {descriptor.ToString()}.");
+                        throw new ProteoformGroupCreateException($"Couldn't handle descriptor {descriptor}.");
                     }
 
                     if (modification == null)
@@ -105,7 +105,9 @@ namespace TopDownProteomics.Proteomics
                     }
                     else if (mod != null)
                     {
-                        if (!mod.GetChemicalFormula().Equals(modification.GetChemicalFormula()))
+                        if (mod is IHasChemicalFormula form1 &&
+                            modification is IHasChemicalFormula form2 &&
+                            !form1.GetChemicalFormula().Equals(form2.GetChemicalFormula()))
                         {
                             throw new ProteoformGroupCreateException(multipleModsErrorMessage);
                         }
@@ -141,9 +143,9 @@ namespace TopDownProteomics.Proteomics
             {
                 return this.Water.GetMass(massType) +
                     this.Residues.Sum(x => x.GetChemicalFormula().GetMass(massType)) +
-                    (this.Modifications?.Sum(x => x.GetChemicalFormula().GetMass(massType)) ?? 0.0) +
-                    (this.NTerminalModification?.GetChemicalFormula().GetMass(massType) ?? 0.0) +
-                    (this.CTerminalModification?.GetChemicalFormula().GetMass(massType) ?? 0.0);
+                    (this.Modifications?.Sum(x => x.Modification.GetMass(massType)) ?? 0.0) +
+                    (this.NTerminalModification?.GetMass(massType) ?? 0.0) +
+                    (this.CTerminalModification?.GetMass(massType) ?? 0.0);
             }
         }
     }

--- a/src/TopDownProteomics/Proteomics/ProteoformModificationWithIndex.cs
+++ b/src/TopDownProteomics/Proteomics/ProteoformModificationWithIndex.cs
@@ -1,30 +1,22 @@
-﻿using TopDownProteomics.Chemistry;
-
-namespace TopDownProteomics.Proteomics
+﻿namespace TopDownProteomics.Proteomics
 {
     /// <summary>Modification on a chemical proteoform that has a zero-based index.</summary>
     /// <seealso cref="IProteoformModificationWithIndex" />
     public class ProteoformModificationWithIndex : IProteoformModificationWithIndex
     {
-        private IProteoformModification _proteoformModification;
-
         /// <summary>Initializes a new instance of the <see cref="ProteoformModificationWithIndex"/> class.</summary>
         /// <param name="proteoformModification">The proteoform modification.</param>
         /// <param name="zeroBasedIndex">  zero-based index.</param>
         public ProteoformModificationWithIndex(IProteoformModification proteoformModification, int zeroBasedIndex)
         {
-            _proteoformModification = proteoformModification;
-            ZeroBasedIndex = zeroBasedIndex;
+            this.Modification = proteoformModification;
+            this.ZeroBasedIndex = zeroBasedIndex;
         }
 
         /// <summary>Gets the zero-based index in the sequence.</summary>
         public int ZeroBasedIndex { get; }
 
-        /// <summary>Gets the chemical formula.</summary>
-        /// <returns></returns>
-        public IChemicalFormula GetChemicalFormula()
-        {
-            return this._proteoformModification.GetChemicalFormula();
-        }
+        /// <summary>The modification.</summary>
+        public IProteoformModification Modification { get; }
     }
 }

--- a/tests/TopDownProteomics.Tests/Chemistry/ChemicalFormulaTest.cs
+++ b/tests/TopDownProteomics.Tests/Chemistry/ChemicalFormulaTest.cs
@@ -59,6 +59,19 @@ namespace TopDownProteomics.Tests.Chemistry
         }
 
         [Test]
+        public void DuplicateElementTest()
+        {
+            string formulaString = "CHCHO";
+
+            this.SimpleParseTest(formulaString, new[]
+            {
+                Tuple.Create("C", 2),
+                Tuple.Create("H", 2),
+                Tuple.Create("O", 1)
+            });
+        }
+
+        [Test]
         public void NegativeParseTest()
         {
             string formulaString = "HN-1O2";

--- a/tests/TopDownProteomics.Tests/ProForma/ModificationLookupTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ModificationLookupTests.cs
@@ -209,7 +209,9 @@ namespace TopDownProteomics.Tests.ProForma
             });
 
             IProteoformModification proteoformModification = _formulaLookup.GetModification(proFormaDescriptor);
-            Assert.AreEqual(chemicalFormula, proteoformModification.GetChemicalFormula());
+            Assert.IsInstanceOf(typeof(IHasChemicalFormula), proteoformModification);
+            var formulaMod = (IHasChemicalFormula)proteoformModification;
+            Assert.AreEqual(chemicalFormula, formulaMod.GetChemicalFormula());
         }
 
         [Test]
@@ -236,7 +238,15 @@ namespace TopDownProteomics.Tests.ProForma
                     new EntityCardinality<IElement>(_elementProvider.GetElement("O"), 6),
                     new EntityCardinality<IElement>(_elementProvider.GetElement("S"), 1),
                 });
-            Assert.IsTrue(chemicalFormula.Equals(mod.GetChemicalFormula()));
+
+            Assert.IsInstanceOf(typeof(IHasChemicalFormula), mod);
+            var formulaMod = (IHasChemicalFormula)mod;
+            Assert.IsTrue(chemicalFormula.Equals(formulaMod.GetChemicalFormula()));
+
+            Assert.IsInstanceOf(typeof(IIdentifiable), mod);
+            var idMod = (IIdentifiable)mod;
+            Assert.AreEqual("MOD:00402", idMod.Id);
+            Assert.AreEqual("Gygi ICAT(TM) d8 modified cysteine", idMod.Name);
         }
     }
 }

--- a/tests/TopDownProteomics.Tests/TestData/ptmlist.txt
+++ b/tests/TopDownProteomics.Tests/TestData/ptmlist.txt
@@ -9,7 +9,7 @@
 
 Description: Controlled vocabulary of posttranslational modifications (PTM)
 Name:        ptmlist.txt
-Release:     2019_11 of 11-Dec-2019
+Release:     2020_05 of 07-Oct-2020
 
 ---------------------------------------------------------------------------
 
@@ -108,6 +108,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141853.
 DR   RESID; AA0026.
 DR   PSI-MOD; MOD:00035.
+DR   Unimod; 35.
 //
 ID   (3R)-3-hydroxyaspartate
 AC   PTM-0371
@@ -125,6 +126,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141848.
 DR   RESID; AA0027.
 DR   PSI-MOD; MOD:00036.
+DR   Unimod; 35.
 //
 ID   (3S)-3-hydroxyhistidine
 AC   PTM-0477
@@ -189,6 +191,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141803.
 DR   RESID; AA0282.
 DR   PSI-MOD; MOD:00287.
+DR   Unimod; 425.
 //
 ID   (3R,4S)-4-hydroxyisoleucine
 AC   PTM-0337
@@ -343,6 +346,7 @@ MM   -2.015650
 MA   -2.02
 LC   Intracellular localisation.
 TR   Archaea; taxId:28890 (Euryarchaeota).
+DR   ChEBI; CHEBI:145325.
 //
 ID   (E)-2,3-didehydrotyrosine
 AC   PTM-0001
@@ -357,6 +361,7 @@ LC   Intracellular localisation.
 TR   Eukaryota; taxId:6073 (Cnidaria).
 DR   RESID; AA0365.
 DR   PSI-MOD; MOD:00370.
+DR   Unimod; 401.
 //
 ID   (Z)-2,3-didehydrotyrosine
 AC   PTM-0002
@@ -371,6 +376,7 @@ LC   Intracellular localisation.
 TR   Eukaryota; taxId:6073 (Cnidaria).
 DR   RESID; AA0183.
 DR   PSI-MOD; MOD:00191.
+DR   Unimod; 401.
 //
 ID   2,3-didehydrotyrosine
 AC   PTM-0008
@@ -384,6 +390,7 @@ MA   -2.02
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:6073 (Cnidaria).
 DR   PSI-MOD; MOD:00706.
+DR   Unimod; 401.
 //
 ID   2,3-didehydroalanine (Cys)
 AC   PTM-0468
@@ -397,8 +404,10 @@ MA   -34.08
 LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:4932 (Saccharomyces cerevisiae).
+DR   ChEBI; CHEBI:90873.
 DR   RESID; AA0181.
 DR   PSI-MOD; MOD:00793.
+DR   Unimod; 368.
 //
 ID   2,3-didehydroalanine (Ser)
 AC   PTM-0006
@@ -413,8 +422,10 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:28890 (Euryarchaeota).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:90873.
 DR   RESID; AA0181.
 DR   PSI-MOD; MOD:00189.
+DR   Unimod; 23.
 //
 ID   2,3-didehydroalanine (Tyr)
 AC   PTM-0647
@@ -428,8 +439,10 @@ MA   -94.11
 LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:90873.
 DR   RESID; AA0181.
 DR   PSI-MOD; MOD:00824.
+DR   Unimod; 400.
 //
 ID   (E)-2,3-didehydrobutyrine
 AC   PTM-0441
@@ -458,6 +471,7 @@ LC   Extracellular localisation.
 TR   Bacteria; taxId:1239 (Firmicutes).
 DR   RESID; AA0182.
 DR   PSI-MOD; MOD:01471.
+DR   Unimod; 23.
 //
 ID   2,3-didehydrobutyrine
 AC   PTM-0007
@@ -471,6 +485,7 @@ MA   -18.02
 LC   Extracellular localisation.
 TR   Bacteria; taxId:1239 (Firmicutes).
 DR   PSI-MOD; MOD:00190.
+DR   Unimod; 23.
 //
 ID   1-amino-2-propanone
 AC   PTM-0379
@@ -517,6 +532,7 @@ TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 DR   RESID; AA0265.
 DR   PSI-MOD; MOD:00270.
+DR   Unimod; 420.
 //
 ID   1-(tryptophan-3-yl)-tryptophan (Trp-Trp) (interchain with W-...)
 AC   PTM-0445
@@ -560,8 +576,10 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   TPQ.
+DR   ChEBI; CHEBI:79027.
 DR   RESID; AA0147.
 DR   PSI-MOD; MOD:00156.
+DR   Unimod; 392.
 //
 ID   2'-cysteinyl-6'-hydroxytryptophan sulfoxide (Trp-Cys)
 AC   PTM-0338
@@ -618,6 +636,7 @@ MA   168.04
 LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Pyruvate.
+DR   ChEBI; CHEBI:149496.
 DR   RESID; AA0391.
 DR   PSI-MOD; MOD:00797.
 //
@@ -737,6 +756,7 @@ TR   Archaea; taxId:79929 (Methanothermobacter marburgensis (strain ATCC BAA-927
 KW   Methylation.
 DR   RESID; AA0273.
 DR   PSI-MOD; MOD:00278.
+DR   Unimod; 34.
 //
 ID   2'-methylsulfonyltryptophan
 AC   PTM-0304
@@ -764,8 +784,23 @@ MM   -17.026549
 MA   -17.03
 LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:1282 (Staphylococcus epidermidis).
+DR   ChEBI; CHEBI:149508.
 DR   RESID; AA0129.
 DR   PSI-MOD; MOD:00138.
+DR   Unimod; 385.
+//
+ID   2-oxo-5,5-dimethylhexanoate
+AC   PTM-0687
+FT   MOD_RES
+TG   Threonine.
+PA   Amino acid backbone.
+PP   N-terminal.
+CF   C4 H5 N-1
+MM   39.03605
+MA   39.08
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+DR   ChEBI; CHEBI:149505.
 //
 ID   2-tetrahydro-2-pyridyl-5-imidazolinone (Lys-Gly)
 AC   PTM-0018
@@ -855,6 +890,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141829.
 DR   RESID; AA0369.
 DR   PSI-MOD; MOD:00374.
+DR   Unimod; 425.
 //
 ID   3',4'-dihydroxyphenylalanine
 AC   PTM-0023
@@ -872,6 +908,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141815.
 DR   RESID; AA0146.
 DR   PSI-MOD; MOD:00155.
+DR   Unimod; 35.
 //
 ID   3',4',5'-trihydroxyphenylalanine
 AC   PTM-0667
@@ -888,6 +925,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141811.
 DR   RESID; AA0263.
 DR   PSI-MOD; MOD:00268.
+DR   Unimod; 425.
 //
 ID   2-hydroxyproline
 AC   PTM-0668
@@ -952,6 +990,19 @@ KW   Prenylation.
 DR   ChEBI; CHEBI:141127.
 DR   RESID; AA0408.
 DR   PSI-MOD; MOD:00817.
+//
+ID   3'-prenyl-2',N2-cyclotryptophan
+AC   PTM-0685
+FT   LIPID
+TG   Tryptophan.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C5 H8
+MM   68.06260
+MA   68.12
+TR   Bacteria; taxId:1117 (Cyanobacteria).
+KW   Prenylation.
+DR   ChEBI; CHEBI:147338.
 //
 ID   3'-histidyl-3-tyrosine (His-Tyr)
 AC   PTM-0027
@@ -1023,9 +1074,10 @@ MA   16.00
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Hydroxylation.
-DR   ChEBI; CHEBI:141835.
+DR   ChEBI; CHEBI:85428.
 DR   RESID; AA0029.
 DR   PSI-MOD; MOD:00038.
+DR   Unimod; 35.
 //
 ID   3-hydroxypyridine-2,5-dicarboxylic acid (Ser-Cys) (with S-...)
 AC   PTM-0454
@@ -1065,8 +1117,9 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141794.
 DR   RESID; AA0322.
 DR   PSI-MOD; MOD:00327.
+DR   Unimod; 35.
 //
-ID   3-hydroxyvaline
+ID   3-hydroxyvaline (Val)
 AC   PTM-0347
 FT   MOD_RES
 TG   Valine.
@@ -1082,6 +1135,62 @@ DR   ChEBI; CHEBI:141793.
 DR   RESID; AA0463.
 DR   PSI-MOD; MOD:01386.
 //
+ID   3-hydroxyvaline (Thr)
+AC   PTM-0692
+FT   MOD_RES
+TG   Threonine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2
+MM   14.015650
+MA   14.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Methylation.
+DR   ChEBI; CHEBI:141793.
+//
+ID   3-hydroxy-D-valine
+AC   PTM-0694
+FT   MOD_RES
+TG   Valine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   O1
+MM   15.994915
+MA   16.00
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   D-amino acid; Hydroxylation.
+DR   ChEBI; CHEBI:149516.
+//
+ID   (3S)-3-methylglutamine
+AC   PTM-0693
+FT   MOD_RES
+TG   Glutamine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2
+MM   14.015650
+MA   14.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Methylation.
+DR   ChEBI; CHEBI:149515.
+//
+ID   3-methylisoleucine
+AC   PTM-0688
+FT   MOD_RES
+TG   Isoleucine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2
+MM   14.015650
+MA   14.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Methylation.
+DR   ChEBI; CHEBI:149510.
+//
 ID   3-methylthioaspartic acid
 AC   PTM-0032
 FT   MOD_RES
@@ -1094,8 +1203,38 @@ MA   46.09
 LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Methylation.
+DR   ChEBI; CHEBI:73599.
 DR   RESID; AA0232.
 DR   PSI-MOD; MOD:00237.
+DR   Unimod; 39.
+//
+ID   3-methylvaline
+AC   PTM-0689
+FT   MOD_RES
+TG   Valine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2
+MM   14.015650
+MA   14.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Methylation.
+DR   ChEBI; CHEBI:149511.
+//
+ID   3-methyl-D-valine
+AC   PTM-0690
+FT   MOD_RES
+TG   Valine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2
+MM   14.015650
+MA   14.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   D-amino acid; Methylation.
+DR   ChEBI; CHEBI:149513.
 //
 ID   3'-nitrotyrosine
 AC   PTM-0434
@@ -1106,9 +1245,10 @@ PP   Anywhere.
 CF   H-1 N1 O2
 MM   44.985078
 MA   45.00
-LC   Extracellular localisation.
-TR   Eukaryota; taxId:40674 (Mammalia).
+LC   Intracellular localisation or Extracellular and lumenal localisation.
+TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Nitration.
+DR   ChEBI; CHEBI:149694.
 DR   RESID; AA0537.
 DR   PSI-MOD; MOD:01786.
 //
@@ -1126,6 +1266,7 @@ TR   Bacteria; taxId:1224 (Proteobacteria), taxId:1239 (Firmicutes).
 TR   Eukaryota; taxId:3041 (Chlorophyta), taxId:33208 (Metazoa).
 DR   RESID; AA0185.
 DR   PSI-MOD; MOD:00193.
+DR   Unimod; 402.
 //
 ID   3-oxoalanine (Ser)
 AC   PTM-0034
@@ -1141,6 +1282,7 @@ TR   Bacteria; taxId:1224 (Proteobacteria).
 TR   Eukaryota; taxId:9606 (Homo sapiens).
 DR   RESID; AA0185.
 DR   PSI-MOD; MOD:00835.
+DR   Unimod; 401.
 //
 ID   3-phenyllactic acid
 AC   PTM-0035
@@ -1155,6 +1297,7 @@ LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:6073 (Cnidaria).
 DR   RESID; AA0128.
 DR   PSI-MOD; MOD:00137.
+DR   Unimod; 7.
 //
 ID   4,5,5'-trihydroxyleucine
 AC   PTM-0372
@@ -1187,6 +1330,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141816.
 DR   RESID; AA0370.
 DR   PSI-MOD; MOD:00375.
+DR   Unimod; 425.
 //
 ID   4-aspartylphosphate
 AC   PTM-0038
@@ -1202,8 +1346,10 @@ TR   Archaea; taxId:28890 (Euryarchaeota).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2763 (Rhodophyta), taxId:3027 (Cryptophyta), taxId:4751 (Fungi), taxId:33090 (Viridiplantae), taxId:38254 (Glaucocystophyceae).
 KW   Phosphoprotein.
+DR   ChEBI; CHEBI:145811.
 DR   RESID; AA0033.
 DR   PSI-MOD; MOD:00042.
+DR   Unimod; 21.
 //
 ID   4-carboxyglutamate
 AC   PTM-0039
@@ -1220,6 +1366,7 @@ KW   Gamma-carboxyglutamic acid.
 DR   ChEBI; CHEBI:84990.
 DR   RESID; AA0032.
 DR   PSI-MOD; MOD:00041.
+DR   Unimod; 299.
 //
 ID   4-cysteinyl-glutamic acid (Cys-Glu)
 AC   PTM-0040
@@ -1248,6 +1395,7 @@ MA   27.97
 LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:1224 (Proteobacteria).
 KW   CTQ; Thioether bond.
+DR   ChEBI; CHEBI:20252.
 DR   RESID; AA0313.
 DR   PSI-MOD; MOD:00318.
 //
@@ -1266,6 +1414,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141854.
 DR   RESID; AA0215.
 DR   PSI-MOD; MOD:00220.
+DR   Unimod; 35.
 //
 ID   4-hydroxyglutamate
 AC   PTM-0453
@@ -1298,6 +1447,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141495.
 DR   RESID; AA0235.
 DR   PSI-MOD; MOD:00240.
+DR   Unimod; 35.
 //
 ID   4-hydroxyproline
 AC   PTM-0043
@@ -1312,9 +1462,10 @@ LC   Intracellular localisation or Extracellular and lumenal localisation.
 TR   Bacteria; taxId:415003 (Microbispora sp. (strain 107891)).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Hydroxylation.
-DR   ChEBI; CHEBI:90860.
+DR   ChEBI; CHEBI:61965.
 DR   RESID; AA0030.
 DR   PSI-MOD; MOD:00039.
+DR   Unimod; 35.
 //
 ID   5-(methoxymethyl)thiazole-4-carboxylic acid (Val-Cys)
 AC   PTM-0373
@@ -1365,6 +1516,7 @@ MA   143.14
 LC   Intracellular localisation.
 TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:1297 (Deinococcus-Thermus).
+DR   ChEBI; CHEBI:78503.
 DR   RESID; AA0502.
 DR   PSI-MOD; MOD:01605.
 //
@@ -1380,8 +1532,10 @@ MA   197.13
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Phosphoprotein.
+DR   ChEBI; CHEBI:156066.
 DR   RESID; AA0170.
 DR   PSI-MOD; MOD:00179.
+DR   Unimod; 396.
 //
 ID   5-glutamyl N2-ornithine
 AC   PTM-0478
@@ -1389,11 +1543,13 @@ FT   MOD_RES
 TG   Glutamate.
 PA   Amino acid side chain.
 PP   C-terminal.
-CF   C6 H12 N4 O1
+CF   C5 H10 N2 O1
+MM   114.079313
 MA   114.15
 LC   Intracellular localisation.
 TR   Archaea; taxId:2267 (Thermoproteaceae).
 KW   Isopeptide bond.
+DR   ChEBI; CHEBI:136763.
 DR   PSI-MOD; MOD:01971.
 //
 ID   5-glutamyl glutamate
@@ -1412,6 +1568,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Isopeptide bond.
 DR   RESID; AA0612.
 DR   PSI-MOD; MOD:01970.
+DR   Unimod; 450.
 //
 ID   5-glutamyl N2-lysine
 AC   PTM-0407
@@ -1426,6 +1583,7 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:1297 (Deinococcus-Thermus).
 KW   Isopeptide bond.
+DR   ChEBI; CHEBI:78526.
 DR   RESID; AA0505.
 DR   PSI-MOD; MOD:01608.
 //
@@ -1484,6 +1642,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:141817.
 DR   RESID; AA0028.
 DR   PSI-MOD; MOD:00037.
+DR   Unimod; 35.
 //
 ID   (5R)-5-hydroxylysine
 AC   PTM-0471
@@ -1500,6 +1659,7 @@ KW   Hydroxylation.
 DR   ChEBI; CHEBI:133442.
 DR   RESID; AA0028.
 DR   PSI-MOD; MOD:01925.
+DR   Unimod; 35.
 //
 ID   (5S)-5-hydroxylysine
 AC   PTM-0472
@@ -1605,6 +1765,7 @@ TR   Archaea; taxId:28890 (Euryarchaeota).
 KW   Methylation.
 DR   RESID; AA0272.
 DR   PSI-MOD; MOD:00277.
+DR   Unimod; 34.
 //
 ID   5-methyloxazole-4-carboxylic acid (Cys-Thr)
 AC   PTM-0461
@@ -1707,6 +1868,7 @@ KW   Bromination.
 DR   ChEBI; CHEBI:61899.
 DR   RESID; AA0179.
 DR   PSI-MOD; MOD:00188.
+DR   Unimod; 340.
 //
 ID   5'-chlorotryptophan
 AC   PTM-0444
@@ -1721,11 +1883,12 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:2005 (Microbispora).
 DR   RESID; AA0180.
 DR   PSI-MOD; MOD:00886.
+DR   Unimod; 936.
 //
-ID   6-(S-cysteinyl)-8alpha-(pros-histidyl)-FAD (Cys-His)
+ID   6-(S-cysteinyl)-8alpha-(pros-histidyl)-FAD (His-Cys)
 AC   PTM-0681
 FT   CROSSLNK
-TG   Cysteine-Histidine.
+TG   Histidine-Cysteine.
 PA   Amino acid side chain-Amino acid side chain.
 PP   Anywhere-Anywhere.
 CF   C36 H41 N13 O17 P2 S1
@@ -1750,6 +1913,7 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:2005 (Microbispora).
 DR   RESID; AA0180.
 DR   PSI-MOD; MOD:00886.
+DR   Unimod; 936.
 //
 ID   7'-hydroxytryptophan
 AC   PTM-0427
@@ -1781,8 +1945,10 @@ TR   Archaea; taxId:28890 (Euryarchaeota).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:83960.
 DR   RESID; AA0168.
 DR   PSI-MOD; MOD:00177.
+DR   Unimod; 213.
 //
 ID   ADP-ribosylasparagine
 AC   PTM-0054
@@ -1796,8 +1962,10 @@ MA   541.30
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:9606 (Homo sapiens).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:142555.
 DR   RESID; AA0231.
 DR   PSI-MOD; MOD:00236.
+DR   Unimod; 213.
 //
 ID   ADP-ribosyl aspartic acid
 AC   PTM-0497
@@ -1812,6 +1980,7 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:138102.
 //
 ID   ADP-ribosylcysteine
 AC   PTM-0055
@@ -1825,8 +1994,10 @@ MA   541.30
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:140607.
 DR   RESID; AA0169.
 DR   PSI-MOD; MOD:00178.
+DR   Unimod; 213.
 //
 ID   ADP-ribosyldiphthamide
 AC   PTM-0672
@@ -1855,6 +2026,7 @@ MA   541.30
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:142540.
 //
 ID   ADP-ribosylglycine
 AC   PTM-0671
@@ -1865,6 +2037,7 @@ PP   C-terminal.
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:142558.
 //
 ID   ADP-ribosylserine
 AC   PTM-0056
@@ -1878,8 +2051,10 @@ MA   541.30
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:9606 (Homo sapiens).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:142556.
 DR   RESID; AA0237.
 DR   PSI-MOD; MOD:00242.
+DR   Unimod; 213.
 //
 ID   ADP-ribosyltyrosine
 AC   PTM-0670
@@ -1890,6 +2065,7 @@ PP   Anywhere.
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   ADP-ribosylation.
+DR   ChEBI; CHEBI:142557.
 //
 ID   Alanine amide
 AC   PTM-0057
@@ -1903,8 +2079,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145896.
 DR   RESID; AA0081.
 DR   PSI-MOD; MOD:00090.
+DR   Unimod; 2.
 //
 ID   Alanine derivative
 AC   PTM-0058
@@ -1939,9 +2117,13 @@ CF   H-3 N-1 O1
 MM   -1.031634
 MA   -1.03
 LC   Extracellular and lumenal localisation.
-TR   Eukaryota; taxId:6052 (Ephydatia muelleri), taxId:7742 (Vertebrata).
+TR   Archaea; taxId:2157 (Archaea).
+TR   Bacteria; taxId:2 (Bacteria).
+TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:131803.
 DR   RESID; AA0121.
 DR   PSI-MOD; MOD:00130.
+DR   Unimod; 352.
 //
 ID   Aminomalonic acid (Ser)
 AC   PTM-0321
@@ -1969,8 +2151,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145897.
 DR   RESID; AA0082.
 DR   PSI-MOD; MOD:00091.
+DR   Unimod; 2.
 //
 ID   Arginine derivative
 AC   PTM-0061
@@ -1993,8 +2177,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145898.
 DR   RESID; AA0083.
 DR   PSI-MOD; MOD:00092.
+DR   Unimod; 2.
 //
 ID   Aspartate 1-(chondroitin 4-sulfate)-ester
 AC   PTM-0334
@@ -2021,6 +2207,7 @@ TR   Bacteria; taxId:562 (Escherichia coli).
 KW   Phosphoprotein.
 DR   RESID; AA0328.
 DR   PSI-MOD; MOD:00333.
+DR   Unimod; 437.
 //
 ID   Aspartic acid 1-amide
 AC   PTM-0063
@@ -2034,8 +2221,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:6491 (Conus geographus), taxId:8395 (Phyllomedusa sauvagei).
 KW   Amidation.
+DR   ChEBI; CHEBI:145899.
 DR   RESID; AA0084.
 DR   PSI-MOD; MOD:00093.
+DR   Unimod; 2.
 //
 ID   Aspartyl aldehyde
 AC   PTM-0064
@@ -2050,6 +2239,7 @@ LC   Intramembrane.
 TR   Eukaryota; taxId:2763 (Rhodophyta), taxId:3027 (Cryptophyta), taxId:33090 (Viridiplantae), taxId:33634 (Stramenopiles), taxId:33682 (Euglenozoa), taxId:38254 (Glaucocystophyceae).
 DR   RESID; AA0373.
 DR   PSI-MOD; MOD:00378.
+DR   Unimod; 447.
 //
 ID   Isoaspartyl glycine isopeptide (Asn-Gly)
 AC   PTM-0489
@@ -2081,6 +2271,21 @@ KW   Isopeptide bond.
 DR   RESID; AA0126.
 DR   PSI-MOD; MOD:01805.
 //
+ID   Isoaspartyl glycine isopeptide (Gly-Asp)
+AC   PTM-0686
+FT   CROSSLNK
+TG   Glycine-Aspartate.
+PA   Amino acid backbone-Amino acid side chain.
+PP   N-terminal-Anywhere.
+CF   H-2 O-1
+MM   -18.010565
+MA   -18.02
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Isopeptide bond.
+DR   RESID; AA0126.
+DR   PSI-MOD; MOD:01805.
+//
 ID   Asymmetric dimethylarginine
 AC   PTM-0066
 FT   MOD_RES
@@ -2096,6 +2301,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:61897.
 DR   RESID; AA0068.
 DR   PSI-MOD; MOD:00077.
+DR   Unimod; 36.
 //
 ID   Beta-decarboxylated aspartate
 AC   PTM-0314
@@ -2321,6 +2527,7 @@ TR   Eukaryota; taxId:7644 (Clypeaster japonicus).
 KW   Bromination.
 DR   RESID; AA0173.
 DR   PSI-MOD; MOD:00182.
+DR   Unimod; 340.
 //
 ID   Cholesterol glycine ester
 AC   PTM-0090
@@ -2337,6 +2544,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143135.
 DR   RESID; AA0309.
 DR   PSI-MOD; MOD:00314.
+DR   Unimod; 432.
 //
 ID   Cis-14-hydroxy-10,13-dioxo-7-heptadecenoic acid aspartate ester
 AC   PTM-0091
@@ -2352,6 +2560,7 @@ TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Lipoprotein.
 DR   RESID; AA0316.
 DR   PSI-MOD; MOD:00321.
+DR   Unimod; 434.
 //
 ID   Citrulline
 AC   PTM-0092
@@ -2365,8 +2574,10 @@ MA   0.98
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   Citrullination.
+DR   ChEBI; CHEBI:83397.
 DR   RESID; AA0214.
 DR   PSI-MOD; MOD:00219.
+DR   Unimod; 7.
 //
 ID   Cyclo[(prolylserin)-O-yl] cysteinate
 AC   PTM-0380
@@ -2742,6 +2953,7 @@ CF   H-2 O-1
 MM   -18.010565
 MA   -18.02
 LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:67723 (Amanita phalloides).
 //
 ID   Cyclopeptide (Tyr-Pro)
@@ -2794,8 +3006,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:6448 (Gastropoda), taxId:6656 (Arthropoda).
 KW   Amidation.
+DR   ChEBI; CHEBI:145900.
 DR   RESID; AA0085.
 DR   PSI-MOD; MOD:00094.
+DR   Unimod; 2.
 //
 ID   Cysteine derivative
 AC   PTM-0103
@@ -2820,6 +3034,7 @@ TR   Bacteria; taxId:2 (Bacteria).
 KW   Methylation.
 DR   RESID; AA0101.
 DR   PSI-MOD; MOD:00110.
+DR   Unimod; 39.
 //
 ID   Cysteine methyl ester
 AC   PTM-0105
@@ -2834,8 +3049,10 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:201174 (Actinobacteria).
 TR   Eukaryota; taxId:4751 (Fungi), taxId:33208 (Metazoa).
 KW   Methylation.
+DR   ChEBI; CHEBI:61989.
 DR   RESID; AA0105.
 DR   PSI-MOD; MOD:00114.
+DR   Unimod; 34.
 //
 ID   Cysteine persulfide
 AC   PTM-0106
@@ -2850,8 +3067,10 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:1224 (Proteobacteria).
 TR   Archaea; taxId:2157 (Archaea).
 TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:61963.
 DR   RESID; AA0269.
 DR   PSI-MOD; MOD:00274.
+DR   Unimod; 421.
 //
 ID   Cysteine sulfenic acid (-SOH)
 AC   PTM-0107
@@ -2870,6 +3089,7 @@ KW   Oxidation.
 DR   ChEBI; CHEBI:61973.
 DR   RESID; AA0205.
 DR   PSI-MOD; MOD:00210.
+DR   Unimod; 35.
 //
 ID   Cysteine sulfinic acid (-SO2H)
 AC   PTM-0108
@@ -2887,6 +3107,7 @@ KW   Oxidation.
 DR   ChEBI; CHEBI:61967.
 DR   RESID; AA0262.
 DR   PSI-MOD; MOD:00267.
+DR   Unimod; 425.
 //
 ID   Cysteine sulfonic acid (-SO3H)
 AC   PTM-0634
@@ -2903,6 +3124,7 @@ KW   Oxidation.
 DR   ChEBI; CHEBI:141830.
 DR   RESID; AA0556.
 DR   PSI-MOD; MOD:00460.
+DR   Unimod; 345.
 //
 ID   Cysteinyl-selenocysteine (Cys-Sec)
 AC   PTM-0109
@@ -2957,6 +3179,7 @@ TG   Alanine.
 PA   Amino acid backbone.
 PP   Protein core.
 LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:8292 (Amphibia).
 KW   D-amino acid.
 DR   ChEBI; CHEBI:29949.
@@ -2978,6 +3201,7 @@ KW   D-amino acid.
 DR   ChEBI; CHEBI:29949.
 DR   RESID; AA0191.
 DR   PSI-MOD; MOD:00858.
+DR   Unimod; 447.
 //
 ID   D-allo-isoleucine
 AC   PTM-0114
@@ -2999,6 +3223,7 @@ TG   Asparagine.
 PA   Amino acid backbone.
 PP   Protein core.
 LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:6530 (Achatina fulica).
 KW   D-amino acid.
 DR   ChEBI; CHEBI:50349.
@@ -3016,8 +3241,10 @@ MM   0.984016
 MA   0.98
 LC   Intracellular localisation or Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:3702 (Arabidopsis thaliana), taxId:7742 (Vertebrata).
+DR   ChEBI; CHEBI:29961.
 DR   RESID; AA0004.
 DR   PSI-MOD; MOD:00684.
+DR   Unimod; 7.
 //
 ID   Deamidated glutamine
 AC   PTM-0117
@@ -3031,8 +3258,10 @@ MA   0.98
 LC   Intracellular localisation or Extracellular and lumenal localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:7742 (Vertebrata).
+DR   ChEBI; CHEBI:29973.
 DR   RESID; AA0006.
 DR   PSI-MOD; MOD:00685.
+DR   Unimod; 7.
 //
 ID   Decarboxylated threonine
 AC   PTM-0354
@@ -3061,6 +3290,37 @@ LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Methylation.
 DR   PSI-MOD; MOD:00783.
+DR   Unimod; 36.
+//
+ID   Diphosphoserine
+AC   PTM-0697
+FT   MOD_RES
+TG   Serine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   H2 O6 P2
+MM   159.93266
+MA   159.96
+LC   Intracellular localisation.
+TR   Eukaryota; taxId:2759 (Eukaryota).
+KW   Phosphoprotein.
+DR   ChEBI; CHEBI:149682.
+DR   Unimod; 898.
+//
+ID   Diphosphothreonine
+AC   PTM-0698
+FT   MOD_RES
+TG   Threonine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   H2 O6 P2
+MM   159.93266
+MA   159.96
+LC   Intracellular localisation.
+TR   Eukaryota; taxId:2759 (Eukaryota).
+KW   Phosphoprotein.
+DR   ChEBI; CHEBI:149684.
+DR   Unimod; 898.
 //
 ID   Diphthamide
 AC   PTM-0118
@@ -3077,6 +3337,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 DR   ChEBI; CHEBI:16692.
 DR   RESID; AA0040.
 DR   PSI-MOD; MOD:00049.
+DR   Unimod; 375.
 //
 ID   D-leucine
 AC   PTM-0119
@@ -3085,6 +3346,7 @@ TG   Leucine.
 PA   Amino acid backbone.
 PP   Protein core.
 LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:6448 (Gastropoda).
 KW   D-amino acid.
 DR   ChEBI; CHEBI:30005.
@@ -3140,6 +3402,7 @@ TG   Serine.
 PA   Amino acid backbone.
 PP   Protein core.
 LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:6908 (Agelenopsis aperta), taxId:515824 (Callistoctopus minor).
 KW   D-amino acid.
 DR   ChEBI; CHEBI:29998.
@@ -3153,6 +3416,7 @@ TG   Threonine.
 PA   Amino acid backbone.
 PP   Protein core.
 LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:78357 (Amanita virosa).
 KW   D-amino acid.
 DR   ChEBI; CHEBI:30014.
@@ -3198,8 +3462,10 @@ MA   438.33
 LC   Intracellular localisation.
 TR   Bacteria; taxId:1224 (Proteobacteria).
 KW   FMN; Phosphoprotein.
+DR   ChEBI; CHEBI:156050.
 DR   RESID; AA0350.
 DR   PSI-MOD; MOD:00355.
+DR   Unimod; 442.
 //
 ID   FMN phosphoryl threonine
 AC   PTM-0126
@@ -3214,8 +3480,10 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
 KW   FMN; Phosphoprotein.
+DR   ChEBI; CHEBI:74257.
 DR   RESID; AA0349.
 DR   PSI-MOD; MOD:00354.
+DR   Unimod; 442.
 //
 ID   Glutamate methyl ester (Gln)
 AC   PTM-0127
@@ -3229,8 +3497,10 @@ MA   15.01
 LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Methylation.
+DR   ChEBI; CHEBI:82795.
 DR   RESID; AA0072.
 DR   PSI-MOD; MOD:00657.
+DR   Unimod; 528.
 //
 ID   Glutamate methyl ester (Glu)
 AC   PTM-0128
@@ -3245,8 +3515,10 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:28890 (Euryarchaeota).
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Methylation.
+DR   ChEBI; CHEBI:82795.
 DR   RESID; AA0072.
 DR   PSI-MOD; MOD:00081.
+DR   Unimod; 34.
 //
 ID   Glutamic acid 1-amide
 AC   PTM-0129
@@ -3260,8 +3532,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145903.
 DR   RESID; AA0087.
 DR   PSI-MOD; MOD:00096.
+DR   Unimod; 2.
 //
 ID   Isoglutamyl lysine isopeptide (Glu-Lys) (interchain with K-...)
 AC   PTM-0397
@@ -3301,8 +3575,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145904.
 DR   RESID; AA0086.
 DR   PSI-MOD; MOD:00095.
+DR   Unimod; 2.
 //
 ID   Glutamine derivative
 AC   PTM-0131
@@ -3325,8 +3601,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145906.
 DR   RESID; AA0088.
 DR   PSI-MOD; MOD:00097.
+DR   Unimod; 2.
 //
 ID   Glycine radical
 AC   PTM-0133
@@ -3339,6 +3617,7 @@ TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:3055 (Chlamydomonas reinhardtii).
 TR   Viruses; taxId:10239 (Viruses).
 KW   Organic radical.
+DR   ChEBI; CHEBI:32722.
 DR   RESID; AA0008.
 DR   PSI-MOD; MOD:00017.
 //
@@ -3522,6 +3801,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143785.
 DR   RESID; AA0163.
 DR   PSI-MOD; MOD:00172.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated asparagine
 AC   PTM-0137
@@ -3535,6 +3815,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143786.
 DR   RESID; AA0158.
 DR   PSI-MOD; MOD:00167.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated aspartate
 AC   PTM-0138
@@ -3548,6 +3829,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143787.
 DR   RESID; AA0159.
 DR   PSI-MOD; MOD:00168.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated carboxyl end
 AC   PTM-0139
@@ -3560,6 +3842,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   GPI-anchor.
 DR   ChEBI; CHEBI:143797.
 DR   PSI-MOD; MOD:00818.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated cysteine
 AC   PTM-0140
@@ -3573,6 +3856,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143798.
 DR   RESID; AA0160.
 DR   PSI-MOD; MOD:00169.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated glycine
 AC   PTM-0141
@@ -3586,6 +3870,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143799.
 DR   RESID; AA0161.
 DR   PSI-MOD; MOD:00170.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated serine
 AC   PTM-0142
@@ -3599,6 +3884,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143800.
 DR   RESID; AA0162.
 DR   PSI-MOD; MOD:00171.
+DR   Unimod; 394.
 //
 ID   GPI-anchor amidated threonine
 AC   PTM-0143
@@ -3612,6 +3898,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143801.
 DR   RESID; AA0164.
 DR   PSI-MOD; MOD:00173.
+DR   Unimod; 394.
 //
 ID   GPI-like-anchor amidated alanine
 AC   PTM-0144
@@ -3664,6 +3951,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143805.
 DR   RESID; AA0165.
 DR   PSI-MOD; MOD:00174.
+DR   Unimod; 394.
 //
 ID   GPI-like-anchor amidated serine
 AC   PTM-0147
@@ -3677,6 +3965,7 @@ KW   GPI-anchor.
 DR   ChEBI; CHEBI:143806.
 DR   RESID; AA0166.
 DR   PSI-MOD; MOD:00175.
+DR   Unimod; 394.
 //
 ID   Histidine amide
 AC   PTM-0148
@@ -3690,8 +3979,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145909.
 DR   RESID; AA0089.
 DR   PSI-MOD; MOD:00098.
+DR   Unimod; 2.
 //
 ID   Hydroxyarginine
 AC   PTM-0498
@@ -3736,6 +4027,22 @@ KW   Hypusine.
 DR   ChEBI; CHEBI:91175.
 DR   RESID; AA0116.
 DR   PSI-MOD; MOD:00125.
+DR   Unimod; 379.
+//
+ID   Deoxyhypusine
+AC   PTM-0684
+FT   MOD_RES
+TG   Lysine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C4 H9 N1
+MM   71.073499
+MA   71.12
+LC   Intracellular localisation.
+TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:82657.
+DR   RESID; AA0564.
+DR   PSI-MOD; MOD:01880.
 //
 ID   Iodotyrosine
 AC   PTM-0411
@@ -3749,6 +4056,7 @@ MA   125.90
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Iodination.
+DR   ChEBI; CHEBI:90870.
 DR   RESID; AA0509.
 DR   PSI-MOD; MOD:01612.
 //
@@ -3764,6 +4072,7 @@ MA   251.79
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Iodination.
+DR   ChEBI; CHEBI:90871.
 DR   RESID; AA0510.
 DR   PSI-MOD; MOD:01613.
 //
@@ -3779,8 +4088,10 @@ MA   469.79
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Iodination.
+DR   ChEBI; CHEBI:90874.
 DR   RESID; AA0177.
 DR   PSI-MOD; MOD:00186.
+DR   Unimod; 397.
 //
 ID   Thyroxine
 AC   PTM-0294
@@ -3794,8 +4105,10 @@ MA   595.68
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Iodination.
+DR   ChEBI; CHEBI:90872.
 DR   RESID; AA0178.
 DR   PSI-MOD; MOD:00187.
+DR   Unimod; 398.
 //
 ID   Isoaspartyl cysteine isopeptide (Cys-Asn)
 AC   PTM-0151
@@ -3979,8 +4292,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145910.
 DR   RESID; AA0090.
 DR   PSI-MOD; MOD:00099.
+DR   Unimod; 2.
 //
 ID   Isoleucine derivative
 AC   PTM-0162
@@ -4003,7 +4318,7 @@ DR   ChEBI; CHEBI:30008.
 DR   RESID; AA0546.
 DR   PSI-MOD; MOD:01840.
 //
-ID   Lactic acid
+ID   D-lactate
 AC   PTM-0163
 FT   MOD_RES
 TG   Serine.
@@ -4014,8 +4329,10 @@ MM   -15.010899
 MA   -15.02
 LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:1282 (Staphylococcus epidermidis).
+DR   ChEBI; CHEBI:149487.
 DR   RESID; AA0186.
 DR   PSI-MOD; MOD:00194.
+DR   Unimod; 403.
 //
 ID   Lanthionine (Cys-Ser)
 AC   PTM-0164
@@ -4059,8 +4376,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145812.
 DR   RESID; AA0091.
 DR   PSI-MOD; MOD:00100.
+DR   Unimod; 2.
 //
 ID   Leucine methyl ester
 AC   PTM-0167
@@ -4076,6 +4395,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Methylation.
 DR   RESID; AA0299.
 DR   PSI-MOD; MOD:00304.
+DR   Unimod; 34.
 //
 ID   Lysine amide
 AC   PTM-0168
@@ -4089,8 +4409,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145912.
 DR   RESID; AA0092.
 DR   PSI-MOD; MOD:00101.
+DR   Unimod; 2.
 //
 ID   Lysine derivative
 AC   PTM-0169
@@ -4115,6 +4437,7 @@ TR   Eukaryota; taxId:4932 (Saccharomyces cerevisiae).
 KW   Methylation.
 DR   RESID; AA0318.
 DR   PSI-MOD; MOD:00323.
+DR   Unimod; 34.
 //
 ID   Lysine tyrosylquinone (Lys-Tyr)
 AC   PTM-0171
@@ -4186,8 +4509,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145913.
 DR   RESID; AA0093.
 DR   PSI-MOD; MOD:00102.
+DR   Unimod; 2.
 //
 ID   Methionine derivative
 AC   PTM-0174
@@ -4210,8 +4535,10 @@ MA   32.00
 LC   Intracellular localisation.
 TR   Bacteria; taxId:584 (Proteus mirabilis).
 KW   Oxidation.
+DR   ChEBI; CHEBI:156065.
 DR   RESID; AA0251.
 DR   PSI-MOD; MOD:00256.
+DR   Unimod; 425.
 //
 ID   Methionine (R)-sulfoxide
 AC   PTM-0480
@@ -4225,8 +4552,10 @@ MA   16.00
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Oxidation.
+DR   ChEBI; CHEBI:45764.
 DR   RESID; AA0581.
 DR   PSI-MOD; MOD:00720.
+DR   Unimod; 35.
 //
 ID   Methionine (S)-sulfoxide
 AC   PTM-0481
@@ -4240,7 +4569,9 @@ MA   16.00
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Oxidation.
+DR   ChEBI; CHEBI:44120.
 DR   PSI-MOD; MOD:00721.
+DR   Unimod; 35.
 //
 ID   Methionine sulfoxide
 AC   PTM-0469
@@ -4254,7 +4585,9 @@ MA   16.00
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Oxidation.
+DR   ChEBI; CHEBI:15989.
 DR   PSI-MOD; MOD:00719.
+DR   Unimod; 35.
 //
 ID   (4R)-5-oxoleucine
 AC   PTM-0492
@@ -4343,6 +4676,7 @@ TR   Eukaryota; taxId:5908 (Tetrahymena pyriformis), taxId:9986 (Oryctolagus cun
 KW   Methylation.
 DR   RESID; AA0062.
 DR   PSI-MOD; MOD:00071.
+DR   Unimod; 37.
 //
 ID   N,N,N-trimethylglycine
 AC   PTM-0485
@@ -4445,8 +4779,10 @@ MA   29.06
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:6446 (Sipunculus nudus), taxId:7586 (Echinodermata), taxId:33682 (Euglenozoa).
 KW   Methylation.
+DR   ChEBI; CHEBI:145671.
 DR   RESID; AA0066.
 DR   PSI-MOD; MOD:00075.
+DR   Unimod; 529.
 //
 ID   N,N-dimethylserine
 AC   PTM-0431
@@ -4463,6 +4799,20 @@ KW   Methylation.
 DR   RESID; AA0534.
 DR   PSI-MOD; MOD:01783.
 //
+ID   3,3-dimethylmethionine
+AC   PTM-0696
+FT   MOD_RES
+TG   Methionine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C2 H4
+MM   28.031300
+MA   28.05
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Methylation.
+DR   ChEBI; CHEBI:149518.
+//
 ID   N2-acetylarginine
 AC   PTM-0180
 FT   MOD_RES
@@ -4475,8 +4825,10 @@ MA   42.04
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Acetylation.
+DR   ChEBI; CHEBI:145666.
 DR   RESID; AA0354.
 DR   PSI-MOD; MOD:00359.
+DR   Unimod; 1.
 //
 ID   N2-succinyltryptophan
 AC   PTM-0181
@@ -4491,6 +4843,7 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:1423 (Bacillus subtilis).
 DR   RESID; AA0130.
 DR   PSI-MOD; MOD:00139.
+DR   Unimod; 64.
 //
 ID   N2,N2-dimethylarginine
 AC   PTM-0459
@@ -4521,6 +4874,7 @@ TR   Eukaryota; taxId:9606 (Homo sapiens).
 KW   Methylation.
 DR   RESID; AA0311.
 DR   PSI-MOD; MOD:00316.
+DR   Unimod; 36.
 //
 ID   N4-methylasparagine
 AC   PTM-0183
@@ -4538,6 +4892,35 @@ KW   Methylation.
 DR   ChEBI; CHEBI:61960.
 DR   RESID; AA0070.
 DR   PSI-MOD; MOD:00079.
+DR   Unimod; 34.
+//
+ID   N4-methyl-D-asparagine
+AC   PTM-0691
+FT   MOD_RES
+TG   Asparagine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2
+MM   14.015650
+MA   14.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   D-amino acid; Methylation.
+DR   ChEBI; CHEBI:149514.
+//
+ID   (3R)-N4-methyl-3-hydroxy-D-asparagine
+AC   PTM-0695
+FT   MOD_RES
+TG   Asparagine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C1 H2 O1
+MM   30.01056
+MA   30.03
+LC   Extracellular and lumenal localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   D-amino acid; Hydroxylation; Methylation.
+DR   ChEBI; CHEBI:149517.
 //
 ID   N5-[4-(S-L-cysteinyl)-5-methyl-1H-imidazol-2-yl]-L-ornithine (Arg-Cys) (interchain with C-...)
 AC   PTM-0678
@@ -4571,6 +4954,7 @@ TR   Eukaryota; taxId:4932 (Saccharomyces cerevisiae).
 KW   Methylation.
 DR   RESID; AA0305.
 DR   PSI-MOD; MOD:00310.
+DR   Unimod; 34.
 //
 ID   N5-methylglutamine
 AC   PTM-0185
@@ -4588,6 +4972,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:61891.
 DR   RESID; AA0071.
 DR   PSI-MOD; MOD:00080.
+DR   Unimod; 34.
 //
 ID   N6-(3,6-diaminohexanoyl)-5-hydroxylysine
 AC   PTM-0474
@@ -4598,6 +4983,7 @@ PP   Anywhere.
 LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Hydroxylation.
+DR   ChEBI; CHEBI:156054.
 DR   PSI-MOD; MOD:01780.
 //
 ID   N6-(ADP-ribosyl)lysine
@@ -4632,6 +5018,7 @@ KW   Pyridoxal phosphate.
 DR   ChEBI; CHEBI:143915.
 DR   RESID; AA0119.
 DR   PSI-MOD; MOD:00128.
+DR   Unimod; 46.
 //
 ID   N6-(retinylidene)lysine
 AC   PTM-0388
@@ -4647,8 +5034,10 @@ TR   Archaea; taxId:28890 (Euryarchaeota), taxId:2236 (Halobacteriaceae).
 TR   Bacteria; taxId:1236 (Gammaproteobacteria).
 TR   Eukaryota; taxId:33154 (Opisthokonta).
 KW   Retinal protein.
+DR   ChEBI; CHEBI:149695.
 DR   RESID; AA0120.
 DR   PSI-MOD; MOD:00129.
+DR   Unimod; 380.
 //
 ID   N6,N6,N6-trimethyl-5-hydroxylysine
 AC   PTM-0186
@@ -4664,6 +5053,7 @@ TR   Eukaryota; taxId:2853 (Cylindrotheca fusiformis).
 KW   Hydroxylation; Methylation.
 DR   RESID; AA0359.
 DR   PSI-MOD; MOD:00364.
+DR   Unimod; 445.
 //
 ID   N6,N6,N6-trimethyllysine
 AC   PTM-0187
@@ -4681,6 +5071,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:61961.
 DR   RESID; AA0074.
 DR   PSI-MOD; MOD:00083.
+DR   Unimod; 37.
 //
 ID   N6,N6-dimethyllysine
 AC   PTM-0188
@@ -4698,6 +5089,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:61976.
 DR   RESID; AA0075.
 DR   PSI-MOD; MOD:00084.
+DR   Unimod; 36.
 //
 ID   N6-1-carboxyethyl lysine
 AC   PTM-0189
@@ -4710,8 +5102,10 @@ MM   72.021129
 MA   72.06
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
+DR   ChEBI; CHEBI:156063.
 DR   RESID; AA0115.
 DR   PSI-MOD; MOD:00124.
+DR   Unimod; 378.
 //
 ID   N6-acetyllysine
 AC   PTM-0190
@@ -4730,6 +5124,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:61930.
 DR   RESID; AA0055.
 DR   PSI-MOD; MOD:00064.
+DR   Unimod; 1.
 //
 ID   N6-biotinyllysine
 AC   PTM-0382
@@ -4748,6 +5143,7 @@ KW   Biotin.
 DR   ChEBI; CHEBI:83144.
 DR   RESID; AA0117.
 DR   PSI-MOD; MOD:00126.
+DR   Unimod; 3.
 //
 ID   N6-carbamoyllysine
 AC   PTM-0675
@@ -4780,6 +5176,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 DR   ChEBI; CHEBI:144366.
 DR   RESID; AA0114.
 DR   PSI-MOD; MOD:00123.
+DR   Unimod; 299.
 //
 ID   N6-crotonyllysine
 AC   PTM-0475
@@ -4808,8 +5205,19 @@ MA   28.01
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:7460 (Apis mellifera).
 KW   Formylation.
+DR   ChEBI; CHEBI:156064.
 DR   RESID; AA0211.
 DR   PSI-MOD; MOD:00216.
+DR   Unimod; 122.
+//
+ID   N6-lactoyllysine
+AC   PTM-0682
+FT   MOD_RES
+TG   Lysine.
+PA   Amino acid side chain.
+PP   Anywhere.
+TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:145324.
 //
 ID   N6-lipoyllysine
 AC   PTM-0383
@@ -4828,6 +5236,7 @@ KW   Lipoyl.
 DR   ChEBI; CHEBI:83099.
 DR   RESID; AA0118.
 DR   PSI-MOD; MOD:00127.
+DR   Unimod; 42.
 //
 ID   N6-malonyllysine
 AC   PTM-0467
@@ -4876,6 +5285,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:61929.
 DR   RESID; AA0076.
 DR   PSI-MOD; MOD:00085.
+DR   Unimod; 34.
 //
 ID   N6-murein peptidoglycan lysine
 AC   PTM-0195
@@ -4904,6 +5314,7 @@ KW   Myristate.
 DR   ChEBI; CHEBI:141129.
 DR   RESID; AA0078.
 DR   PSI-MOD; MOD:00087.
+DR   Unimod; 45.
 //
 ID   N6-palmitoyl lysine
 AC   PTM-0197
@@ -4921,6 +5332,7 @@ KW   Palmitate.
 DR   ChEBI; CHEBI:138936.
 DR   RESID; AA0077.
 DR   PSI-MOD; MOD:00086.
+DR   Unimod; 47.
 //
 ID   N6-poly(methylaminopropyl)lysine
 AC   PTM-0198
@@ -4980,6 +5392,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 DR   ChEBI; CHEBI:137955.
 DR   RESID; AA0532.
 DR   PSI-MOD; MOD:01781.
+DR   Unimod; 1289.
 //
 ID   N6-(2-hydroxyisobutyryl)lysine
 AC   PTM-0638
@@ -5007,6 +5420,7 @@ MA   87.09
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Hydroxylation.
+DR   ChEBI; CHEBI:149490.
 //
 ID   N6-poly(beta-hydroxybutyryl)lysine
 AC   PTM-0639
@@ -5057,6 +5471,7 @@ TR   Eukaryota; taxId:40674 (Mammalia).
 DR   ChEBI; CHEBI:138019.
 DR   RESID; AA0475.
 DR   PSI-MOD; MOD:01398.
+DR   Unimod; 58.
 //
 ID   N-[(12R)-12-hydroxymyristoyl]cysteine
 AC   PTM-0419
@@ -5104,6 +5519,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:83683.
 DR   RESID; AA0041.
 DR   PSI-MOD; MOD:00050.
+DR   Unimod; 1.
 //
 ID   N-acetylaspartate
 AC   PTM-0200
@@ -5120,6 +5536,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:140856.
 DR   RESID; AA0042.
 DR   PSI-MOD; MOD:00051.
+DR   Unimod; 1.
 //
 ID   N-acetylcysteine
 AC   PTM-0201
@@ -5137,6 +5554,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:133372.
 DR   RESID; AA0043.
 DR   PSI-MOD; MOD:00052.
+DR   Unimod; 1.
 //
 ID   N-acetylglutamate
 AC   PTM-0202
@@ -5153,6 +5571,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:140857.
 DR   RESID; AA0044.
 DR   PSI-MOD; MOD:00053.
+DR   Unimod; 1.
 //
 ID   N-acetylglycine
 AC   PTM-0203
@@ -5169,6 +5588,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:133369.
 DR   RESID; AA0046.
 DR   PSI-MOD; MOD:00055.
+DR   Unimod; 1.
 //
 ID   N-acetylisoleucine
 AC   PTM-0204
@@ -5186,6 +5606,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:140858.
 DR   RESID; AA0047.
 DR   PSI-MOD; MOD:00056.
+DR   Unimod; 1.
 //
 ID   N-acetylmethionine
 AC   PTM-0205
@@ -5204,6 +5625,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:133414.
 DR   RESID; AA0049.
 DR   PSI-MOD; MOD:00058.
+DR   Unimod; 1.
 //
 ID   N-acetylproline
 AC   PTM-0206
@@ -5221,6 +5643,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:140859.
 DR   RESID; AA0050.
 DR   PSI-MOD; MOD:00059.
+DR   Unimod; 1.
 //
 ID   N-acetylserine
 AC   PTM-0207
@@ -5239,6 +5662,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:83690.
 DR   RESID; AA0051.
 DR   PSI-MOD; MOD:00060.
+DR   Unimod; 1.
 //
 ID   N-acetylthreonine
 AC   PTM-0208
@@ -5256,6 +5680,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:133375.
 DR   RESID; AA0052.
 DR   PSI-MOD; MOD:00061.
+DR   Unimod; 1.
 //
 ID   N-acetyltyrosine
 AC   PTM-0209
@@ -5272,6 +5697,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:140860.
 DR   RESID; AA0053.
 DR   PSI-MOD; MOD:00062.
+DR   Unimod; 1.
 //
 ID   N-acetylvaline
 AC   PTM-0210
@@ -5289,6 +5715,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:133371.
 DR   RESID; AA0054.
 DR   PSI-MOD; MOD:00063.
+DR   Unimod; 1.
 //
 ID   N-carbamoylalanine
 AC   PTM-0374
@@ -5303,6 +5730,7 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:195064 (Ectothiorhodospira mobilis).
 DR   RESID; AA0343.
 DR   PSI-MOD; MOD:00348.
+DR   Unimod; 5.
 //
 ID   S-(2-succinyl)cysteine
 AC   PTM-0674
@@ -5318,6 +5746,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 DR   ChEBI; CHEBI:143134.
 DR   RESID; AA0561.
 DR   PSI-MOD; MOD:01889.
+DR   Unimod; 957.
 //
 ID   S-carbamoylcysteine
 AC   PTM-0649
@@ -5332,6 +5761,7 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 DR   RESID; AA0332.
 DR   PSI-MOD; MOD:00337.
+DR   Unimod; 5.
 //
 ID   S-cyanocysteine
 AC   PTM-0650
@@ -5346,6 +5776,7 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 DR   RESID; AA0333.
 DR   PSI-MOD; MOD:00338.
+DR   Unimod; 438.
 //
 ID   S-(2,3-dicarboxypropyl)cysteine
 AC   PTM-0676
@@ -5371,6 +5802,7 @@ TR   Eukaryota; taxId:147550 (Sordariomycetes).
 KW   Glycoprotein.
 DR   RESID; AA0058.
 DR   PSI-MOD; MOD:00067.
+DR   Unimod; 54.
 //
 ID   N-formylglycine
 AC   PTM-0211
@@ -5386,6 +5818,7 @@ TR   Eukaryota; taxId:7460 (Apis mellifera).
 KW   Formylation.
 DR   RESID; AA0057.
 DR   PSI-MOD; MOD:00066.
+DR   Unimod; 122.
 //
 ID   N-formylmethionine
 AC   PTM-0212
@@ -5400,8 +5833,10 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Formylation.
+DR   ChEBI; CHEBI:49298.
 DR   RESID; AA0021.
 DR   PSI-MOD; MOD:00482.
+DR   Unimod; 122.
 //
 ID   Nitrated tyrosine
 AC   PTM-0213
@@ -5416,6 +5851,7 @@ LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Nitration.
 DR   PSI-MOD; MOD:01352.
+DR   Unimod; 354.
 //
 ID   N-methylalanine
 AC   PTM-0214
@@ -5432,6 +5868,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Methylation.
 DR   RESID; AA0061.
 DR   PSI-MOD; MOD:00070.
+DR   Unimod; 34.
 //
 ID   N-methylglycine
 AC   PTM-0483
@@ -5446,6 +5883,7 @@ TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Methylation.
 DR   RESID; AA0063.
 DR   PSI-MOD; MOD:00072.
+DR   Unimod; 34.
 //
 ID   N-methylisoleucine
 AC   PTM-0215
@@ -5461,6 +5899,7 @@ TR   Bacteria; taxId:303 (Pseudomonas putida).
 KW   Methylation.
 DR   RESID; AA0336.
 DR   PSI-MOD; MOD:00341.
+DR   Unimod; 34.
 //
 ID   N-methylleucine
 AC   PTM-0216
@@ -5477,6 +5916,7 @@ TR   Eukaryota; taxId:68564 (Petrosia ficiformis).
 KW   Methylation.
 DR   RESID; AA0337.
 DR   PSI-MOD; MOD:00342.
+DR   Unimod; 34.
 //
 ID   N-methylmethionine
 AC   PTM-0217
@@ -5493,6 +5933,7 @@ TR   Eukaryota; taxId:3055 (Chlamydomonas reinhardtii).
 KW   Methylation.
 DR   RESID; AA0064.
 DR   PSI-MOD; MOD:00073.
+DR   Unimod; 34.
 //
 ID   N-methylphenylalanine
 AC   PTM-0218
@@ -5508,6 +5949,7 @@ TR   Bacteria; taxId:2 (Bacteria).
 KW   Methylation.
 DR   RESID; AA0065.
 DR   PSI-MOD; MOD:00074.
+DR   Unimod; 34.
 //
 ID   N-methylproline
 AC   PTM-0219
@@ -5553,6 +5995,7 @@ TR   Bacteria; taxId:1224 (Proteobacteria).
 KW   Methylation.
 DR   RESID; AA0338.
 DR   PSI-MOD; MOD:00343.
+DR   Unimod; 34.
 //
 ID   N-myristoyl glycine
 AC   PTM-0221
@@ -5570,6 +6013,7 @@ KW   Myristate.
 DR   ChEBI; CHEBI:133050.
 DR   RESID; AA0059.
 DR   PSI-MOD; MOD:00068.
+DR   Unimod; 45.
 //
 ID   N-palmitoyl cysteine
 AC   PTM-0222
@@ -5587,6 +6031,7 @@ KW   Palmitate.
 DR   ChEBI; CHEBI:143147.
 DR   RESID; AA0060.
 DR   PSI-MOD; MOD:00069.
+DR   Unimod; 47.
 //
 ID   N-palmitoyl glycine
 AC   PTM-0223
@@ -5603,6 +6048,7 @@ KW   Palmitate.
 DR   ChEBI; CHEBI:143223.
 DR   RESID; AA0339.
 DR   PSI-MOD; MOD:00344.
+DR   Unimod; 47.
 //
 ID   N-pyruvate 2-iminyl-cysteine
 AC   PTM-0224
@@ -5618,6 +6064,7 @@ TR   Bacteria; taxId:543 (Enterobacteriaceae).
 KW   Pyruvate.
 DR   RESID; AA0274.
 DR   PSI-MOD; MOD:00279.
+DR   Unimod; 422.
 //
 ID   N-pyruvate 2-iminyl-valine
 AC   PTM-0225
@@ -5633,6 +6080,7 @@ TR   Eukaryota; taxId:9606 (Homo sapiens).
 KW   Pyruvate.
 DR   RESID; AA0275.
 DR   PSI-MOD; MOD:00280.
+DR   Unimod; 422.
 //
 ID   O-(2-aminoethylphosphoryl)serine
 AC   PTM-0399
@@ -5727,8 +6175,10 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:638 (Arsenophonus nasoniae), taxId:112 (Planctomycetales).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Phosphopantetheine; Phosphoprotein.
+DR   ChEBI; CHEBI:64479.
 DR   RESID; AA0150.
 DR   PSI-MOD; MOD:00159.
+DR   Unimod; 49.
 //
 ID   O-(phosphoribosyl dephospho-coenzyme A)serine
 AC   PTM-0389
@@ -5744,6 +6194,7 @@ TR   Bacteria; taxId:158 (Treponema denticola), taxId:1224 (Proteobacteria), tax
 KW   Phosphoprotein.
 DR   RESID; AA0167.
 DR   PSI-MOD; MOD:00176.
+DR   Unimod; 395.
 //
 ID   O-(sn-1-glycerophosphoryl)serine
 AC   PTM-0230
@@ -5759,6 +6210,7 @@ TR   Bacteria; taxId:1224 (Proteobacteria).
 KW   Phosphoprotein.
 DR   RESID; AA0264.
 DR   PSI-MOD; MOD:00269.
+DR   Unimod; 419.
 //
 ID   O-8alpha-FAD tyrosine
 AC   PTM-0231
@@ -5774,6 +6226,7 @@ TR   Bacteria; taxId:303 (Pseudomonas putida).
 KW   FAD.
 DR   RESID; AA0145.
 DR   PSI-MOD; MOD:00154.
+DR   Unimod; 50.
 //
 ID   O-acetylserine
 AC   PTM-0232
@@ -5790,6 +6243,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:141128.
 DR   RESID; AA0364.
 DR   PSI-MOD; MOD:00369.
+DR   Unimod; 1.
 //
 ID   O-acetylthreonine
 AC   PTM-0233
@@ -5806,6 +6260,7 @@ KW   Acetylation.
 DR   ChEBI; CHEBI:141025.
 DR   RESID; AA0423.
 DR   PSI-MOD; MOD:01171.
+DR   Unimod; 1.
 //
 ID   O-AMP-serine
 AC   PTM-0651
@@ -5835,6 +6290,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Nucleotide-binding; Phosphoprotein.
 DR   RESID; AA0267.
 DR   PSI-MOD; MOD:00272.
+DR   Unimod; 405.
 //
 ID   O-AMP-tyrosine
 AC   PTM-0332
@@ -5852,6 +6308,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Nucleotide-binding; Phosphoprotein.
 DR   RESID; AA0203.
 DR   PSI-MOD; MOD:00208.
+DR   Unimod; 405.
 //
 ID   O-decanoyl threonine
 AC   PTM-0235
@@ -5868,6 +6325,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143546.
 DR   RESID; AA0387.
 DR   PSI-MOD; MOD:00392.
+DR   Unimod; 449.
 //
 ID   O-decanoyl serine
 AC   PTM-0234
@@ -5884,6 +6342,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143549.
 DR   RESID; AA0385.
 DR   PSI-MOD; MOD:00390.
+DR   Unimod; 449.
 //
 ID   Omega-hydroxyceramide glutamate ester
 AC   PTM-0236
@@ -5915,6 +6374,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:65280.
 DR   RESID; AA0069.
 DR   PSI-MOD; MOD:00078.
+DR   Unimod; 34.
 //
 ID   Omega-N-methylated arginine
 AC   PTM-0238
@@ -5957,6 +6417,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143548.
 DR   RESID; AA0290.
 DR   PSI-MOD; MOD:00295.
+DR   Unimod; 426.
 //
 ID   O-octanoyl threonine
 AC   PTM-0240
@@ -5973,6 +6434,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143547.
 DR   RESID; AA0386.
 DR   PSI-MOD; MOD:00391.
+DR   Unimod; 426.
 //
 ID   O-palmitoyl serine
 AC   PTM-0241
@@ -5989,6 +6451,7 @@ KW   Palmitate.
 DR   ChEBI; CHEBI:140185.
 DR   RESID; AA0080.
 DR   PSI-MOD; MOD:00089.
+DR   Unimod; 47.
 //
 ID   O-palmitoyl threonine
 AC   PTM-0242
@@ -6005,6 +6468,7 @@ KW   Palmitate.
 DR   ChEBI; CHEBI:143621.
 DR   RESID; AA0079.
 DR   PSI-MOD; MOD:00088.
+DR   Unimod; 47.
 //
 ID   O-UMP-histidine
 AC   PTM-0500
@@ -6020,6 +6484,7 @@ TR   Bacteria; taxId:2 (Bacteria).
 KW   Nucleotide-binding; Phosphoprotein.
 DR   RESID; AA0372.
 DR   PSI-MOD; MOD:00377.
+DR   Unimod; 417.
 //
 ID   O-UMP-serine
 AC   PTM-0501
@@ -6034,6 +6499,7 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Nucleotide-binding; Phosphoprotein.
+DR   ChEBI; CHEBI:156051.
 //
 ID   O-UMP-threonine
 AC   PTM-0502
@@ -6048,6 +6514,7 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Nucleotide-binding; Phosphoprotein.
+DR   ChEBI; CHEBI:156052.
 //
 ID   O-UMP-tyrosine
 AC   PTM-0333
@@ -6064,8 +6531,10 @@ TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2797 (Bangiophyceae).
 TR   Viruses; taxId:10239 (Viruses).
 KW   Nucleotide-binding; Phosphoprotein.
+DR   ChEBI; CHEBI:90602.
 DR   RESID; AA0256.
 DR   PSI-MOD; MOD:00261.
+DR   Unimod; 417.
 //
 ID   Oxazole-4-carboxylic acid (Cys-Ser)
 AC   PTM-0376
@@ -6182,8 +6651,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:61957.
 DR   RESID; AA0094.
 DR   PSI-MOD; MOD:00103.
+DR   Unimod; 2.
 //
 ID   Phosphatidylethanolamine amidated glycine
 AC   PTM-0249
@@ -6214,8 +6685,10 @@ LC   Intracellular localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Phosphoprotein.
+DR   ChEBI; CHEBI:83226.
 DR   RESID; AA0222.
 DR   PSI-MOD; MOD:00227.
+DR   Unimod; 21.
 //
 ID   Phosphocysteine
 AC   PTM-0251
@@ -6230,8 +6703,10 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
 KW   Phosphoprotein.
+DR   ChEBI; CHEBI:61975.
 DR   RESID; AA0034.
 DR   PSI-MOD; MOD:00043.
+DR   Unimod; 21.
 //
 ID   Phosphohistidine
 AC   PTM-0252
@@ -6248,6 +6723,7 @@ TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Phosphoprotein.
 DR   PSI-MOD; MOD:00890.
+DR   Unimod; 21.
 //
 ID   Phosphoserine
 AC   PTM-0253
@@ -6267,6 +6743,7 @@ KW   Phosphoprotein.
 DR   ChEBI; CHEBI:83421.
 DR   RESID; AA0037.
 DR   PSI-MOD; MOD:00046.
+DR   Unimod; 21.
 //
 ID   Phosphothreonine
 AC   PTM-0254
@@ -6285,6 +6762,7 @@ KW   Phosphoprotein.
 DR   ChEBI; CHEBI:61977.
 DR   RESID; AA0038.
 DR   PSI-MOD; MOD:00047.
+DR   Unimod; 21.
 //
 ID   Phosphotyrosine
 AC   PTM-0255
@@ -6304,6 +6782,7 @@ KW   Phosphoprotein.
 DR   ChEBI; CHEBI:82620.
 DR   RESID; AA0039.
 DR   PSI-MOD; MOD:00048.
+DR   Unimod; 21.
 //
 ID   PolyADP-ribosyl aspartic acid
 AC   PTM-0494
@@ -6354,8 +6833,10 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:35762 (Planobispora rosea).
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145914.
 DR   RESID; AA0095.
 DR   PSI-MOD; MOD:00104.
+DR   Unimod; 2.
 //
 ID   Pros-8alpha-FAD histidine
 AC   PTM-0258
@@ -6372,6 +6853,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   FAD.
 DR   RESID; AA0144.
 DR   PSI-MOD; MOD:00153.
+DR   Unimod; 50.
 //
 ID   Pros-methylhistidine
 AC   PTM-0259
@@ -6388,6 +6870,7 @@ TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   Methylation.
 DR   RESID; AA0073.
 DR   PSI-MOD; MOD:00082.
+DR   Unimod; 34.
 //
 ID   Pros-phosphohistidine
 AC   PTM-0260
@@ -6399,10 +6882,14 @@ CF   H1 O3 P1
 MM   79.966331
 MA   79.98
 LC   Intracellular localisation.
+TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
+TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Phosphoprotein.
+DR   ChEBI; CHEBI:64837.
 DR   RESID; AA0036.
 DR   PSI-MOD; MOD:00045.
+DR   Unimod; 21.
 //
 ID   Pyridine-2,5-dicarboxylic acid (Ser-Cys) (with S-...)
 AC   PTM-0357
@@ -6440,8 +6927,10 @@ TR   Archaea; taxId:28890 (Euryarchaeota).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Pyrrolidone carboxylic acid.
+DR   ChEBI; CHEBI:87215.
 DR   RESID; AA0031.
 DR   PSI-MOD; MOD:00040.
+DR   Unimod; 28.
 //
 ID   Pyrrolidone carboxylic acid (Glu)
 AC   PTM-0262
@@ -6455,8 +6944,10 @@ MA   -18.02
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:9913 (Bos taurus).
 KW   Pyrrolidone carboxylic acid.
+DR   ChEBI; CHEBI:87215.
 DR   RESID; AA0031.
 DR   PSI-MOD; MOD:00420.
+DR   Unimod; 27.
 //
 ID   Pyrroloquinoline quinone (Glu-Tyr)
 AC   PTM-0263
@@ -6484,8 +6975,10 @@ MA   -33.09
 LC   Intracellular localisation.
 TR   Bacteria; taxId:1239 (Firmicutes).
 KW   Pyruvate.
+DR   ChEBI; CHEBI:45360.
 DR   RESID; AA0127.
 DR   PSI-MOD; MOD:00136.
+DR   Unimod; 382.
 //
 ID   Pyruvic acid (Ser)
 AC   PTM-0266
@@ -6501,8 +6994,10 @@ TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Pyruvate.
+DR   ChEBI; CHEBI:45360.
 DR   RESID; AA0127.
 DR   PSI-MOD; MOD:00807.
+DR   Unimod; 385.
 //
 ID   Pyruvic acid (Tyr)
 AC   PTM-0662
@@ -6516,6 +7011,7 @@ MA   -93.13
 LC   Intracellular localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Pyruvate.
+DR   ChEBI; CHEBI:45360.
 DR   RESID; AA0127.
 DR   PSI-MOD; MOD:01661.
 //
@@ -6608,6 +7104,7 @@ TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Chromophore.
 DR   RESID; AA0207.
 DR   PSI-MOD; MOD:00212.
+DR   Unimod; 407.
 //
 ID   S-(coelenterazin-3a-yl)cysteine
 AC   PTM-0428
@@ -6635,8 +7132,10 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
+DR   ChEBI; CHEBI:61892.
 DR   RESID; AA0252.
 DR   PSI-MOD; MOD:00257.
+DR   Unimod; 416.
 //
 ID   S-12-hydroxyfarnesyl cysteine
 AC   PTM-0269
@@ -6653,6 +7152,7 @@ KW   Prenylation.
 DR   ChEBI; CHEBI:143699.
 DR   RESID; AA0103.
 DR   PSI-MOD; MOD:00112.
+DR   Unimod; 376.
 //
 ID   S-4a-FMN cysteine
 AC   PTM-0270
@@ -6669,6 +7169,7 @@ TR   Eukaryota; taxId:3702 (Arabidopsis thaliana).
 KW   FMN.
 DR   RESID; AA0351.
 DR   PSI-MOD; MOD:00356.
+DR   Unimod; 443.
 //
 ID   S-6-FMN cysteine
 AC   PTM-0271
@@ -6684,6 +7185,7 @@ TR   Bacteria; taxId:1224 (Proteobacteria).
 KW   FMN.
 DR   RESID; AA0220.
 DR   PSI-MOD; MOD:00225.
+DR   Unimod; 409.
 //
 ID   S-8alpha-FAD cysteine
 AC   PTM-0272
@@ -6700,6 +7202,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   FAD.
 DR   RESID; AA0143.
 DR   PSI-MOD; MOD:00152.
+DR   Unimod; 50.
 //
 ID   S-archaeol cysteine
 AC   PTM-0273
@@ -6716,6 +7219,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143704.
 DR   RESID; AA0223.
 DR   PSI-MOD; MOD:00228.
+DR   Unimod; 410.
 //
 ID   S-bacillithiol cysteine disulfide
 AC   PTM-0452
@@ -6770,6 +7274,7 @@ TR   Bacteria; taxId:91347 (Enterobacterales).
 TR   Eukaryota; taxId:40674 (Mammalia).
 DR   RESID; AA0025.
 DR   PSI-MOD; MOD:00765.
+DR   Unimod; 312.
 //
 ID   S-diacylglycerol cysteine
 AC   PTM-0274
@@ -6786,6 +7291,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:140656.
 DR   RESID; AA0107.
 DR   PSI-MOD; MOD:00116.
+DR   Unimod; 377.
 //
 ID   Serine amide
 AC   PTM-0275
@@ -6800,8 +7306,10 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:146537 (Streptomyces azureus).
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145915.
 DR   RESID; AA0096.
 DR   PSI-MOD; MOD:00105.
+DR   Unimod; 2.
 //
 ID   Serine microcin E492 siderophore ester
 AC   PTM-0276
@@ -6816,6 +7324,7 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:573 (Klebsiella pneumoniae).
 DR   RESID; AA0374.
 DR   PSI-MOD; MOD:00379.
+DR   Unimod; 448.
 //
 ID   S-farnesyl cysteine
 AC   PTM-0277
@@ -6832,6 +7341,7 @@ KW   Prenylation.
 DR   ChEBI; CHEBI:86019.
 DR   RESID; AA0102.
 DR   PSI-MOD; MOD:00111.
+DR   Unimod; 44.
 //
 ID   S-geranylgeranyl cysteine
 AC   PTM-0278
@@ -6848,6 +7358,7 @@ KW   Prenylation.
 DR   ChEBI; CHEBI:86021.
 DR   RESID; AA0104.
 DR   PSI-MOD; MOD:00113.
+DR   Unimod; 48.
 //
 ID   S-glutathionyl cysteine
 AC   PTM-0311
@@ -6864,6 +7375,7 @@ TR   Eukaryota; taxId:3981 (Hevea brasiliensis), taxId:7742 (Vertebrata).
 KW   Glutathionylation.
 DR   RESID; AA0229.
 DR   PSI-MOD; MOD:00234.
+DR   Unimod; 55.
 //
 ID   S-Lysyl-methionine sulfilimine (Met-Lys) (interchain with K-...)
 AC   PTM-0401
@@ -6903,6 +7415,7 @@ TR   Eukaryota; taxId:3055 (Chlamydomonas reinhardtii).
 KW   Methylation.
 DR   RESID; AA0234.
 DR   PSI-MOD; MOD:00239.
+DR   Unimod; 34.
 //
 ID   S-methylmethionine
 AC   PTM-0636
@@ -6932,8 +7445,10 @@ LC   Intracellular localisation.
 TR   Bacteria; taxId:1224 (Proteobacteria).
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   S-nitrosylation.
+DR   ChEBI; CHEBI:149494.
 DR   RESID; AA0230.
 DR   PSI-MOD; MOD:00235.
+DR   Unimod; 275.
 //
 ID   S-palmitoyl cysteine
 AC   PTM-0281
@@ -6950,6 +7465,7 @@ KW   Palmitate.
 DR   ChEBI; CHEBI:74151.
 DR   RESID; AA0106.
 DR   PSI-MOD; MOD:00115.
+DR   Unimod; 47.
 //
 ID   S-selanylcysteine
 AC   PTM-0282
@@ -6965,6 +7481,7 @@ TR   Bacteria; taxId:562 (Escherichia coli).
 KW   Selenium.
 DR   RESID; AA0277.
 DR   PSI-MOD; MOD:00282.
+DR   Unimod; 423.
 //
 ID   S-stearoyl cysteine
 AC   PTM-0283
@@ -6996,6 +7513,7 @@ TR   Eukaryota; taxId:9606 (Homo sapiens).
 KW   Sulfation.
 DR   RESID; AA0361.
 DR   PSI-MOD; MOD:00366.
+DR   Unimod; 40.
 //
 ID   Sulfothreonine
 AC   PTM-0285
@@ -7011,6 +7529,7 @@ TR   Eukaryota; taxId:36329 (Plasmodium falciparum (isolate 3D7)).
 KW   Sulfation.
 DR   RESID; AA0362.
 DR   PSI-MOD; MOD:00367.
+DR   Unimod; 40.
 //
 ID   Sulfotyrosine
 AC   PTM-0286
@@ -7024,8 +7543,10 @@ MA   80.06
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa), taxId:33090 (Viridiplantae).
 KW   Sulfation.
+DR   ChEBI; CHEBI:65286.
 DR   RESID; AA0172.
 DR   PSI-MOD; MOD:00181.
+DR   Unimod; 40.
 //
 ID   Symmetric dimethylarginine
 AC   PTM-0287
@@ -7042,6 +7563,7 @@ KW   Methylation.
 DR   ChEBI; CHEBI:88221.
 DR   RESID; AA0067.
 DR   PSI-MOD; MOD:00076.
+DR   Unimod; 36.
 //
 ID   Tele-(1,2,3-trihydroxypropan-2-yl)histidine
 AC   PTM-0416
@@ -7071,6 +7593,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   FAD.
 DR   RESID; AA0221.
 DR   PSI-MOD; MOD:00226.
+DR   Unimod; 50.
 //
 ID   Tele-8alpha-FMN histidine
 AC   PTM-0289
@@ -7086,6 +7609,7 @@ TR   Bacteria; taxId:69006 (Corynebacterium sp. (strain P-1)).
 KW   FMN.
 DR   RESID; AA0352.
 DR   PSI-MOD; MOD:00357.
+DR   Unimod; 409.
 //
 ID   Tele-methylhistidine
 AC   PTM-0290
@@ -7101,6 +7625,7 @@ TR   Eukaryota; taxId:5791 (Physarum polycephalum), taxId:7742 (Vertebrata).
 KW   Methylation.
 DR   RESID; AA0317.
 DR   PSI-MOD; MOD:00322.
+DR   Unimod; 34.
 //
 ID   Tele-phosphohistidine
 AC   PTM-0325
@@ -7112,10 +7637,14 @@ CF   H1 O3 P1
 MM   79.966331
 MA   79.98
 LC   Intracellular localisation.
+TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
+TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Phosphoprotein.
+DR   ChEBI; CHEBI:83586.
 DR   RESID; AA0035.
 DR   PSI-MOD; MOD:00044.
+DR   Unimod; 21.
 //
 ID   Thiazole-4-carboxylic acid (Arg-Cys)
 AC   PTM-0460
@@ -7300,6 +7829,19 @@ KW   Thioether bond.
 DR   RESID; AA0485.
 DR   PSI-MOD; MOD:01408.
 //
+ID   Thiazolidine linkage to a ring-opened DNA abasic site
+AC   PTM-0683
+FT   MOD_RES
+TG   Cysteine.
+PA   Amino acid side chain.
+PP   N-terminal.
+LC   Intracellular localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+TR   Eukaryota; taxId:2759 (Eukaryota).
+TR   Viruses; taxId:10239 (Viruses).
+KW   Covalent protein-DNA linkage.
+DR   ChEBI; CHEBI:145793.
+//
 ID   Threonine 5-hydroxy-oxazole-4-carbonthionic acid (Thr-Cys)
 AC   PTM-0458
 FT   CROSSLNK
@@ -7326,8 +7868,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145916.
 DR   RESID; AA0097.
 DR   PSI-MOD; MOD:00106.
+DR   Unimod; 2.
 //
 ID   Threonyl lysine isopeptide (Lys-Thr) (interchain with T-...)
 AC   PTM-0326
@@ -7392,8 +7936,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145917.
 DR   RESID; AA0098.
 DR   PSI-MOD; MOD:00107.
+DR   Unimod; 2.
 //
 ID   Tryptophan derivative
 AC   PTM-0297
@@ -7432,6 +7978,7 @@ LC   Extracellular and lumenal localisation.
 TR   Bacteria; taxId:1224 (Proteobacteria).
 DR   RESID; AA0148.
 DR   PSI-MOD; MOD:00157.
+DR   Unimod; 392.
 //
 ID   Tryptophyl-tyrosyl-methioninium (Trp-Tyr) (with M-...)
 AC   PTM-0328
@@ -7471,8 +8018,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145918.
 DR   RESID; AA0099.
 DR   PSI-MOD; MOD:00108.
+DR   Unimod; 2.
 //
 ID   Valine amide
 AC   PTM-0303
@@ -7486,8 +8035,10 @@ MA   -0.98
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Amidation.
+DR   ChEBI; CHEBI:145919.
 DR   RESID; AA0100.
 DR   PSI-MOD; MOD:00109.
+DR   Unimod; 2.
 //
 ID   L-isoglutamyl histamine
 AC   PTM-0488
@@ -7532,6 +8083,7 @@ KW   Lipoprotein.
 DR   ChEBI; CHEBI:143203.
 DR   RESID; AA0308.
 DR   PSI-MOD; MOD:00313.
+DR   Unimod; 431.
 //
 ID   C-linked (Man) hydroxytryptophan
 AC   PTM-0504
@@ -7562,6 +8114,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Glycoprotein.
 DR   RESID; AA0217.
 DR   PSI-MOD; MOD:00222.
+DR   Unimod; 41.
 //
 ID   N-linked (DATDGlc) asparagine
 AC   PTM-0506
@@ -7630,6 +8183,7 @@ LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Glycation.
 DR   PSI-MOD; MOD:01347.
+DR   Unimod; 41.
 //
 ID   N-linked (Glc) (glycation) valine
 AC   PTM-0510
@@ -7657,6 +8211,7 @@ LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Glycation.
 DR   PSI-MOD; MOD:00929.
+DR   Unimod; 512.
 //
 ID   N-linked (GalNAc) asparagine
 AC   PTM-0512
@@ -7708,6 +8263,7 @@ TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Glycoprotein.
 DR   RESID; AA0327.
 DR   PSI-MOD; MOD:00332.
+DR   Unimod; 41.
 //
 ID   N-linked (Glc...) arginine
 AC   PTM-0516
@@ -7838,6 +8394,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Glycoprotein.
 DR   RESID; AA0151.
 DR   PSI-MOD; MOD:00831.
+DR   Unimod; 43.
 //
 ID   N-linked (GlcNAc...) asparagine
 AC   PTM-0528
@@ -8049,6 +8606,7 @@ TR   Eukaryota; taxId:33090 (Viridiplantae).
 KW   Glycoprotein; Hydroxylation.
 DR   RESID; AA0212.
 DR   PSI-MOD; MOD:00217.
+DR   Unimod; 408.
 //
 ID   O-linked (Ara...) hydroxyproline
 AC   PTM-0546
@@ -8119,6 +8677,7 @@ TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   Glycoprotein.
 DR   RESID; AA0404.
 DR   PSI-MOD; MOD:00812.
+DR   Unimod; 295.
 //
 ID   O-linked (Fuc...) serine
 AC   PTM-0551
@@ -8144,6 +8703,7 @@ TR   Eukaryota; taxId:33208 (Metazoa).
 KW   Glycoprotein.
 DR   RESID; AA0405.
 DR   PSI-MOD; MOD:00813.
+DR   Unimod; 295.
 //
 ID   O-linked (Fuc...) threonine
 AC   PTM-0553
@@ -8193,6 +8753,7 @@ LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   Glycoprotein; Hydroxylation.
 DR   PSI-MOD; MOD:01914.
+DR   Unimod; 907.
 //
 ID   O-linked (Gal...) hydroxylysine
 AC   PTM-0557
@@ -8291,8 +8852,10 @@ MA   203.19
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Glycoprotein.
+DR   ChEBI; CHEBI:53604.
 DR   RESID; AA0154.
 DR   PSI-MOD; MOD:00163.
+DR   Unimod; 43.
 //
 ID   O-linked (GalNAc...) serine
 AC   PTM-0565
@@ -8326,8 +8889,10 @@ MA   203.19
 LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Glycoprotein.
+DR   ChEBI; CHEBI:87075.
 DR   RESID; AA0155.
 DR   PSI-MOD; MOD:00164.
+DR   Unimod; 43.
 //
 ID   O-linked (GalNAc...) threonine
 AC   PTM-0568
@@ -8412,6 +8977,19 @@ LC   Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   Glycoprotein.
 //
+ID   O-linked (Glc) threonine
+AC   PTM-0700
+FT   CARBOHYD
+TG   Threonine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C6 H10 O5
+MM   162.052823
+MA   162.14
+LC   Intracellular localisation.
+TR   Eukaryota; taxId:40674 (Mammalia).
+KW   Glycoprotein.
+//
 ID   O-linked (Glc) tyrosine
 AC   PTM-0575
 FT   CARBOHYD
@@ -8426,6 +9004,7 @@ TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Glycoprotein.
 DR   RESID; AA0157.
 DR   PSI-MOD; MOD:00166.
+DR   Unimod; 41.
 //
 ID   O-linked (Glc...) tyrosine
 AC   PTM-0576
@@ -8452,6 +9031,7 @@ TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Glycoprotein.
 DR   RESID; AA0291.
 DR   PSI-MOD; MOD:00296.
+DR   Unimod; 54.
 //
 ID   O-linked (GlcNAc) hydroxyproline
 AC   PTM-0578
@@ -8491,6 +9071,7 @@ LC   Intracellular localisation or Extracellular and lumenal localisation.
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Glycoprotein.
+DR   ChEBI; CHEBI:90838.
 DR   RESID; AA0398.
 DR   PSI-MOD; MOD:00805.
 //
@@ -8505,6 +9086,19 @@ TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:40674 (Mammalia).
 KW   Glycoprotein.
 //
+ID   O-alpha-linked (GlcNAc) threonine
+AC   PTM-0701
+FT   CARBOHYD
+TG   Threonine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C8 H13 N1 O5
+MM   203.079373
+MA   203.19
+LC   Intracellular localisation or Extracellular and lumenal localisation.
+TR   Eukaryota; taxId:2759 (Eukaryota).
+KW   Glycoprotein.
+//
 ID   O-linked (GlcNAc) threonine
 AC   PTM-0582
 FT   CARBOHYD
@@ -8517,6 +9111,7 @@ MA   203.19
 LC   Intracellular localisation or Extracellular and lumenal localisation.
 TR   Eukaryota; taxId:2759 (Eukaryota).
 KW   Glycoprotein.
+DR   ChEBI; CHEBI:90840.
 DR   RESID; AA0399.
 DR   PSI-MOD; MOD:00806.
 //
@@ -8566,6 +9161,7 @@ TR   Eukaryota; taxId:44689 (Dictyostelium discoideum).
 KW   Glycoprotein; Phosphoprotein.
 DR   RESID; AA0296.
 DR   PSI-MOD; MOD:00301.
+DR   Unimod; 428.
 //
 ID   O-linked (GlcNAc6P) serine
 AC   PTM-0587
@@ -8667,6 +9263,7 @@ TR   Eukaryota; taxId:5654 (Trypanosomatidae).
 KW   Glycoprotein; Phosphoprotein.
 DR   RESID; AA0297.
 DR   PSI-MOD; MOD:00302.
+DR   Unimod; 429.
 //
 ID   O-linked (Man1P...) serine
 AC   PTM-0595
@@ -9051,6 +9648,7 @@ TR   Eukaryota; taxId:7742 (Vertebrata).
 KW   Glycoprotein.
 DR   RESID; AA0152.
 DR   PSI-MOD; MOD:00161.
+DR   Unimod; 41.
 //
 ID   S-linked (Glc...) cysteine
 AC   PTM-0627
@@ -9136,4 +9734,3 @@ KW   Glycoprotein.
 Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
 Distributed under the Creative Commons Attribution (CC BY 4.0) License
 -----------------------------------------------------------------------
-


### PR DESCRIPTION
It has become clear that when one creates hash codes to compare two ProForma strings, collapsing everything to formulas will not work. This PR addresses that by:

- changing the proteoform hash to use modifications (not always formulas)
- handling formulas with duplicate elements
- updating ptmlist.txt (for future work of conversion)