### PR TITLE
Mod Name Lookup + Hash Mass

### DIFF
--- a/src/TopDownProteomics/ProForma/Validation/CompositeModificationLookup.cs
+++ b/src/TopDownProteomics/ProForma/Validation/CompositeModificationLookup.cs
@@ -46,7 +46,7 @@ namespace TopDownProteomics.ProForma.Validation
                     return lookup.GetModification(descriptor);
             }
 
-            throw new ProteoformGroupCreateException($"Couldn't handle value for descriptor {descriptor.ToString()}.");
+            throw new ProteoformGroupCreateException($"Couldn't handle value for descriptor {descriptor}.");
         }
     }
 }

--- a/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
+++ b/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
@@ -59,7 +59,9 @@ namespace TopDownProteomics.ProteoformHash
                 originalProFormaTerm.TagGroups == null &&
                 originalProFormaTerm.UnlocalizedTags == null)
             {
-                return new ChemicalProteoformHash(originalProFormaTerm.Sequence);
+                IProteoformGroup simpleGroup = this._proteoformGroupFactory.CreateProteoformGroup(originalProFormaTerm.Sequence);
+
+                return new ChemicalProteoformHash(originalProFormaTerm.Sequence, simpleGroup);
             }
 
             // Create proteoform group (flattens all features into Ids)
@@ -159,7 +161,7 @@ namespace TopDownProteomics.ProteoformHash
                     tagGroups: tagGroups,
                     globalModifications: globalModifications);
                 string hash = new ProFormaWriter().WriteString(proFormaTerm);
-                return new ChemicalProteoformHash(hash);
+                return new ChemicalProteoformHash(hash, proteoformGroup);
             }
 
             throw new Exception("Cannot get amino acid sequence for the proteoform group.");
@@ -196,11 +198,14 @@ namespace TopDownProteomics.ProteoformHash
             return mass.ToString();
         }
 
-        private class ChemicalProteoformHash : IChemicalProteoformHash
+        private class ChemicalProteoformHash : IChemicalProteoformHash, IHasMass
         {
-            public ChemicalProteoformHash(string hash)
+            private IHasMass _hasMass;
+
+            public ChemicalProteoformHash(string hash, IHasMass hasMass)
             {
                 Hash = hash;
+                _hasMass = hasMass;
             }
 
             public string Hash { get; }
@@ -208,6 +213,8 @@ namespace TopDownProteomics.ProteoformHash
             public bool HasProForma => true;
 
             public string ProForma => Hash;
+
+            public double GetMass(MassType massType) => _hasMass.GetMass(massType);
         }
     }
 }

--- a/src/TopDownProteomics/Proteomics/ProteoformGroupFactory.cs
+++ b/src/TopDownProteomics/Proteomics/ProteoformGroupFactory.cs
@@ -136,6 +136,18 @@ namespace TopDownProteomics.Proteomics
                 modificationGroups, globalModifications, _water);
         }
 
+        /// <summary>
+        /// Creates the proteoform group for a simple sequence of amino acids.
+        /// </summary>
+        /// <param name="sequence">The sequence.</param>
+        /// <returns></returns>
+        public IProteoformGroup CreateProteoformGroup(string sequence)
+        {
+            var residues = sequence.Select(x => _residueProvider.GetResidue(x)).ToArray();
+
+            return new ProteoformGroup(residues, null, null, null, null, null, null, _water);
+        }
+
         private class LocalizedModification : ProteoformModificationBase, IProteoformLocalizedModification
         {
             public LocalizedModification(IProteoformMassDelta modificationDelta, int zeroBasedStartIndex, int zeroBasedEndIndex)

--- a/tests/TopDownProteomics.Tests/ProForma/ModificationLookupTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ModificationLookupTests.cs
@@ -112,8 +112,8 @@ namespace TopDownProteomics.Tests.ProForma
 
             // If using modification name, must have no ending or end in proper ending
             Assert.IsTrue(lookup.CanHandleDescriptor(new ProFormaDescriptor(ProFormaKey.Name, key, "Something")));
+            Assert.IsFalse(lookup.CanHandleDescriptor(new ProFormaDescriptor(ProFormaKey.Name, "Something")));
             Assert.IsFalse(lookup.CanHandleDescriptor(new ProFormaDescriptor(ProFormaKey.Name, ProFormaEvidenceType.Brno, "Something")));
-            Assert.AreEqual(lookup.CanHandleDescriptor(new ProFormaDescriptor(ProFormaKey.Name, "Something")), isDefault);
 
             // This is malformed and must be interpreted as a mod "name" ... will fail when looking up modification
             //Assert.AreEqual(lookup.CanHandleDescriptor(new ProFormaDescriptor(ProFormaKey.Name, $"Something [{key}]")), isDefault);
@@ -247,6 +247,18 @@ namespace TopDownProteomics.Tests.ProForma
             var idMod = (IIdentifiable)mod;
             Assert.AreEqual("MOD:00402", idMod.Id);
             Assert.AreEqual("Gygi ICAT(TM) d8 modified cysteine", idMod.Name);
+        }
+
+        [Test]
+        public void MultipleDefaultLookups()
+        {
+            var lookup = new CompositeModificationLookup(new[] { _psiModLookup, _unimodLookup });
+
+            var mod_psi = lookup.GetModification(new ProFormaDescriptor(ProFormaKey.Name, "3-hydroxy-L-proline"));
+            Assert.IsNotNull(mod_psi);
+
+            var mod_uni = lookup.GetModification(new ProFormaDescriptor(ProFormaKey.Name, "Trimethyl"));
+            Assert.IsNotNull(mod_uni);
         }
     }
 }


### PR DESCRIPTION
* improves modification lookup by name
* adds IHasMass interface to the proteoform hash that is returned (will probably make this part of the IChemicalProteoformHash in the future so it is more discoverable, don't want to commit to that just yet)