### PR TITLE
Mass Descriptors to standardize on 4 decimal places

### DIFF
--- a/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
+++ b/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
@@ -193,9 +193,9 @@ namespace TopDownProteomics.ProteoformHash
         private string GetMassString(double mass)
         {
             if (mass >= 0.0)
-                return $"+{mass}";
+                return $"+{mass:N4}";
 
-            return mass.ToString();
+            return mass.ToString("N4");
         }
 
         private class ChemicalProteoformHash : IChemicalProteoformHash, IHasMass

--- a/tests/TopDownProteomics.Tests/IO/PsiModOboParserTest.cs
+++ b/tests/TopDownProteomics.Tests/IO/PsiModOboParserTest.cs
@@ -20,7 +20,7 @@ namespace TopDownProteomics.Tests.IO
             List<PsiModTerm> result = new List<PsiModTerm>(parser.Parse(GetFilePath()));
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2077, result.Count);
+            Assert.AreEqual(2098, result.Count);
             Assert.AreEqual("MOD:00812", result[812].Id);
             Assert.AreEqual("alkylated residue", result[1].Name);
             Assert.AreEqual("A protein modification that effectively converts an L-serine residue to O3-glycosylserine.", result[2].Definition);
@@ -63,11 +63,11 @@ namespace TopDownProteomics.Tests.IO
             CollectionAssert.Contains(result[5].IsA.ToList(), "MOD:00917");
 
             PsiModTerm formylMethionine = result[30];
-            Assert.AreEqual(9, formylMethionine.ExternalReferences.Count);
+            Assert.AreEqual(8, formylMethionine.ExternalReferences.Count);
             CollectionAssert.Contains(formylMethionine.ExternalReferences.Select(x => x.Id).ToList(), "AA0021#FMET");
             CollectionAssert.Contains(formylMethionine.ExternalReferences.Select(x => x.Name).ToList(), "RESID");
 
-            Assert.AreEqual(11, formylMethionine.Synonyms.Count);
+            Assert.AreEqual(10, formylMethionine.Synonyms.Count);
             CollectionAssert.Contains(formylMethionine.Synonyms.Select(x => x.Scope).ToList(), "EXACT");
             CollectionAssert.Contains(formylMethionine.Synonyms.Select(x => x.Text).ToList(), "2-formylamino-4-(methylthio)butanoic acid");
             CollectionAssert.Contains(formylMethionine.Synonyms.Select(x => x.Type).ToList(), "PSI-MOD-alternate");

--- a/tests/TopDownProteomics.Tests/ProteoformHash/ChemicalProteoformHashTests.cs
+++ b/tests/TopDownProteomics.Tests/ProteoformHash/ChemicalProteoformHashTests.cs
@@ -107,21 +107,21 @@ namespace TopDownProteomics.Tests.ProteoformHash
         [Test]
         public void ConsistentFormulas()
         {
-            // Convert all modifications to PSI-MOD accessions
+            // Merge duplicate elements
             this.TestHash("SEQUE[Formula:CHCHO]NCE", "SEQUE[Formula:C2H2O]NCE");
         }
 
         [Test]
         public void StripLeadingTrailingZeros()
         {
-            // Remove leading and trailing zeros on mass modifications
+            // Remove leading and ensure 4 decimal places on mass modifications
 
-            this.TestHash("SEQUE[+42.050]NCE", "SEQUE[+42.05]NCE");
-            this.TestHash("SEQUE[+042.05]NCE", "SEQUE[+42.05]NCE");
-            this.TestHash("SEQUE[+00042.05000]NCE", "SEQUE[+42.05]NCE");
-            this.TestHash("SEQUE[-17.050]NCE", "SEQUE[-17.05]NCE");
-            this.TestHash("SEQUE[-017.05]NCE", "SEQUE[-17.05]NCE");
-            this.TestHash("SEQUE[-00017.05000]NCE", "SEQUE[-17.05]NCE");
+            this.TestHash("SEQUE[+42.050]NCE", "SEQUE[+42.0500]NCE");
+            this.TestHash("SEQUE[+042.05]NCE", "SEQUE[+42.0500]NCE");
+            this.TestHash("SEQUE[+00042.05000]NCE", "SEQUE[+42.0500]NCE");
+            this.TestHash("SEQUE[-17.050]NCE", "SEQUE[-17.0500]NCE");
+            this.TestHash("SEQUE[-017.05]NCE", "SEQUE[-17.0500]NCE");
+            this.TestHash("SEQUE[-00017.05000]NCE", "SEQUE[-17.0500]NCE");
         }
 
         private void TestHash(string proForma, string expectedHash)

--- a/tests/TopDownProteomics.Tests/TestData/PSI-MOD.obo
+++ b/tests/TopDownProteomics.Tests/TestData/PSI-MOD.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 ontology: mod
-date: 11:12:2020 15:38
+date: 10:03:2021 14:36
 saved-by: Paul M. Thomas
 subsetdef: PSI-MOD-slim "subset of protein modifications"
 synonymtypedef: DeltaMass-label "Label from MS DeltaMass" EXACT
@@ -17,9 +17,9 @@ synonymtypedef: Unimod-description "Description (full_name) from Unimod" RELATED
 synonymtypedef: Unimod-interim "Interim label from Unimod" RELATED
 synonymtypedef: UniProt-feature "Protein feature description from UniProtKB" EXACT
 default-namespace: PSI-MOD
-remark: PSI-MOD version: 1.026.0
+remark: PSI-MOD version: 1.031.2
 remark: RESID release: 75.00
-remark: ISO-8601 date: 2020-12-11 15:38Z
+remark: ISO-8601 date: 2021-03-10 14:36Z
 remark: Annotation note 01 - "[PSI-MOD:ref]" has been replaced by PubMed:18688235.
 remark: Annotation note 02 - When an entry in the RESID Database is annotated with different sources because the same modification can arise from different encoded amino acids, then the PSI-MOD definition for each different source instance carries the RESID cross-reference followed by a hash symbol "#" and a 3 or 4 character label. When an entry in the RESID Database is annotated as a general modification with the same enzymatic activity producing different chemical structures depending on natural variation in the nonproteinaceous substrate, on secondary modifications that do not change the nature of the primary modification, or on a combination of a primary and one or more secondary modifications on the same residue, then the PSI-MOD definition for each different instance carries the RESID cross-reference followed by the special tag "#var".
 remark: Annotation note 03 - When an entry in the Unimod database is annotated as a general modification, and one or more instance sites are listed, then the PSI-MOD definition for each different site instance carries the Unimod cross-reference followed by a hash symbol and an amino acid code, "N-term" or "C-term".
@@ -625,13 +625,12 @@ is_a: MOD:01441 ! natural, standard, encoded residue
 [Term]
 id: MOD:00030
 name: N-formyl-L-methionine residue
-def: "A protein modification that effectively converts a source amino acid residue to an N-formyl-L-methionine, a natural pretranslational modification." [ChEBI:33718, OMSSA:22, PubMed:10825024, PubMed:11152118, PubMed:2165784, PubMed:3042771, PubMed:8758896, RESID:AA0021#FMET, Unimod:107#N-term]
+def: "A protein modification that effectively converts a source amino acid residue to an N-formyl-L-methionine, a natural pretranslational modification." [ChEBI:33718, OMSSA:22, PubMed:10825024, PubMed:11152118, PubMed:2165784, PubMed:3042771, PubMed:8758896, RESID:AA0021#FMET]
 subset: PSI-MOD-slim
 synonym: "(2S)-2-formylamino-4-(methylsulfanyl)butanoic acid" EXACT RESID-systematic []
 synonym: "2-formamido-4-(methylsulfanyl)butanoic acid" EXACT RESID-alternate []
 synonym: "2-formylamino-4-(methylthio)butanoic acid" EXACT RESID-alternate []
 synonym: "2-formylazanyl-4-(methylsulfanyl)butanoic acid" EXACT RESID-alternate []
-synonym: "Addition of N-formyl met" RELATED Unimod-description []
 synonym: "fMet" EXACT PSI-MOD-label []
 synonym: "FormylMet" RELATED PSI-MS-label []
 synonym: "MOD_RES N-formylmethionine" EXACT UniProt-feature []
@@ -647,10 +646,7 @@ xref: MassMono: "160.043225"
 xref: Origin: "M"
 xref: Source: "natural"
 xref: TermSpec: "N-term"
-xref: Unimod: "Unimod:107"
-is_a: MOD:00409 ! N-formylated residue
 is_a: MOD:00868 ! natural, non-standard encoded residue
-is_a: MOD:01696 ! alpha-amino acylated residue
 
 [Term]
 id: MOD:00031
@@ -1615,8 +1611,8 @@ xref: Origin: "C"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:1"
-is_a: MOD:00645 ! S-acetylated residue
-is_a: MOD:00646 ! acetylated L-cysteine
+is_a: MOD:00645 ! mono S-acetylated residue
+is_a: MOD:00646 ! monoacetylated L-cysteine
 
 [Term]
 id: MOD:00066
@@ -3678,7 +3674,7 @@ xref: Source: "natural"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:64"
 xref: UniProt: "PTM-0181"
-is_a: MOD:00457 ! alpha-amino succinylated residue
+is_a: MOD:02081 ! alpha-amino succinylated residue
 is_a: MOD:00918 ! modified L-tryptophan residue
 
 [Term]
@@ -4239,8 +4235,7 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:41"
 xref: UniProt: "PTM-0626"
 is_a: MOD:00426 ! S-glycosylated residue
-is_a: MOD:00433 ! glucosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00433 ! monoglucosylated residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -4265,10 +4260,9 @@ xref: Origin: "K"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:393"
-is_a: MOD:00037 ! 5-hydroxy-L-lysine
+relationship: derives_from MOD:00037 ! 5-hydroxy-L-lysine
+is_a: MOD:00912 ! modified L-lysine residue
 is_a: MOD:00396 ! O-glycosylated residue
-is_a: MOD:00476 ! galactosylated residue
-is_a: MOD:00726 ! glucosylated
 
 [Term]
 id: MOD:00163
@@ -4292,7 +4286,7 @@ xref: Origin: "S"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0564"
-is_a: MOD:00563 ! N-acetylaminogalactosylated residue
+is_a: MOD:00563 ! mono-N-acetylaminogalactosylated residue
 is_a: MOD:01675 ! O-(N-acetylamino)hexosyl-L-serine
 
 [Term]
@@ -4318,7 +4312,7 @@ xref: Origin: "T"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0567"
-is_a: MOD:00563 ! N-acetylaminogalactosylated residue
+is_a: MOD:00563 ! mono-N-acetylaminogalactosylated residue
 is_a: MOD:01676 ! O-(N-acetylamino)hexosyl-L-threonine
 
 [Term]
@@ -4344,8 +4338,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0535"
 is_a: MOD:00006 ! N-glycosylated residue
-is_a: MOD:00595 ! mannosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00595 ! monomannosylated residue
 is_a: MOD:00918 ! modified L-tryptophan residue
 
 [Term]
@@ -4370,8 +4363,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:41"
 xref: UniProt: "PTM-0575"
-is_a: MOD:00433 ! glucosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00433 ! monoglucosylated residue
 is_a: MOD:01927 ! O-glycosyl-L-tyrosine
 
 [Term]
@@ -4609,7 +4601,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:213"
 xref: UniProt: "PTM-0053"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:00752 ! monoadenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00902 ! modified L-arginine residue
 
 [Term]
@@ -4638,7 +4630,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:213"
 xref: UniProt: "PTM-0055"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:00752 ! monoadenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -4826,8 +4818,8 @@ is_a: MOD:00972 ! monobrominated L-phenylalanine
 
 [Term]
 id: MOD:00186
-name: 3',3'',5'-triiodo-L-thyronine
-def: "A protein modification that effectively substitutes an L-tyrosine residue with 3',3'',5'-triiodo-L-thyronine." [ChEBI:18258, DeltaMass:0, RESID:AA0177, Unimod:397]
+name: 3,3',5-triiodo-L-thyronine
+def: "A protein modification that effectively substitutes an L-tyrosine residue with 3,3',5-triiodo-L-thyronine." [ChEBI:18258, DeltaMass:0, RESID:AA0177, Unimod:397]
 comment: From DeltaMass: Average Mass: 470.
 subset: PSI-MOD-slim
 synonym: "(S)-2-amino-3-[4-(4-hydroxy-3-iodophenoxy)-3,5-diiodophenyl]propanoic acid" EXACT RESID-systematic []
@@ -4854,7 +4846,6 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:397"
 xref: UniProt: "PTM-0295"
-is_a: MOD:00502 ! triiodinated residue
 is_a: MOD:00998 ! iodinated tyrosine
 
 [Term]
@@ -5039,6 +5030,7 @@ xref: UniProt: "PTM-0049"
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:02055 ! crosslinked L-serine residue
 is_a: MOD:01882 ! 5-imidazolinone ring crosslinked residues (Gly)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:00193
@@ -5117,6 +5109,7 @@ xref: UniProt: "PTM-0045"
 is_a: MOD:02040 ! crosslinked L-alanine residue
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:01882 ! 5-imidazolinone ring crosslinked residues (Gly)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:00196
@@ -5144,6 +5137,7 @@ xref: UniProt: "PTM-0047"
 is_a: MOD:02044 ! crosslinked L-cysteine residue
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:01882 ! 5-imidazolinone ring crosslinked residues (Gly)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:00197
@@ -5304,6 +5298,7 @@ xref: Formula: "C 4 H 6 N 2 O 2"
 xref: MassAvg: "114.10"
 xref: MassMono: "114.042927"
 xref: Origin: "N"
+xref: Source: "natural"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0115"
@@ -5718,6 +5713,8 @@ xref: TermSpec: "N-term"
 xref: UniProt: "PTM-0151"
 is_a: MOD:02042 ! crosslinked L-asparagine residue
 is_a: MOD:02044 ! crosslinked L-cysteine residue
+is_a: MOD:00946 ! crosslinked residues with loss of ammonia
+is_a: MOD:00688 ! isopeptide crosslinked residues
 
 [Term]
 id: MOD:00222
@@ -5742,8 +5739,7 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:41"
 xref: UniProt: "PTM-0505"
 is_a: MOD:00421 ! C-glycosylated residue
-is_a: MOD:00595 ! mannosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00595 ! monomannosylated residue
 is_a: MOD:00918 ! modified L-tryptophan residue
 
 [Term]
@@ -5798,7 +5794,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:409"
 xref: UniProt: "PTM-0271"
-is_a: MOD:00896 ! FMN modified residue
+is_a: MOD:02084 ! 6-FMN modified residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -6077,6 +6073,7 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:275"
 xref: UniProt: "PTM-0280"
 is_a: MOD:00905 ! modified L-cysteine residue
+is_a: MOD:02077 ! nitrosylated residue
 
 [Term]
 id: MOD:00236
@@ -6100,7 +6097,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:213"
 xref: UniProt: "PTM-0054"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:00752 ! monoadenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00903 ! modified L-asparagine residue
 
 [Term]
@@ -6235,7 +6232,7 @@ xref: Origin: "N"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:414"
-is_a: MOD:00160 ! N4-glycosyl-L-asparagine
+is_a: MOD:00903 ! modified L-asparagine residue
 
 [Term]
 id: MOD:00242
@@ -6262,7 +6259,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:213"
 xref: UniProt: "PTM-0056"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:00752 ! monoadenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00916 ! modified L-serine residue
 
 [Term]
@@ -6286,7 +6283,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0376"
 is_a: MOD:02044 ! crosslinked L-cysteine residue
 is_a: MOD:01421 ! oxazole/oxazoline ring crosslinked residues (Ser)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00244
@@ -6309,6 +6306,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0381"
 is_a: MOD:02044 ! crosslinked L-cysteine residue
 is_a: MOD:01421 ! oxazole/oxazoline ring crosslinked residues (Ser)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:00245
@@ -6331,7 +6329,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0377"
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:01421 ! oxazole/oxazoline ring crosslinked residues (Ser)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00246
@@ -6354,7 +6352,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0378"
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00247
@@ -6377,7 +6375,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0363"
 is_a: MOD:02055 ! crosslinked L-serine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00248
@@ -6400,7 +6398,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0375"
 is_a: MOD:02053 ! crosslinked L-phenylalanine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00249
@@ -6422,7 +6420,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0360"
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00250
@@ -6443,7 +6441,7 @@ xref: Source: "hypothetical"
 xref: TermSpec: "none"
 is_a: MOD:02051 ! crosslinked L-lysine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:00251
@@ -7646,7 +7644,7 @@ xref: Origin: "E"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:213"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:02087 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00906 ! modified L-glutamic acid residue
 
 [Term]
@@ -8308,7 +8306,6 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:435"
 is_a: MOD:00912 ! modified L-lysine residue
-is_a: MOD:01187 ! L-pyrrolysine residue
 
 [Term]
 id: MOD:00327
@@ -8445,8 +8442,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:41"
 xref: UniProt: "PTM-0515"
-is_a: MOD:00433 ! glucosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00433 ! monoglucosylated residue
 is_a: MOD:01980 ! omega-N-glycosyl-L-arginine
 
 [Term]
@@ -8989,7 +8985,7 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:442"
 xref: UniProt: "PTM-0126"
 is_a: MOD:00917 ! modified L-threonine residue
-is_a: MOD:01164 ! riboflavin-phosphoryl
+is_a: MOD:01164 ! riboflavin-phosphorylated residue
 
 [Term]
 id: MOD:00355
@@ -9016,11 +9012,11 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:442"
 xref: UniProt: "PTM-0125"
 is_a: MOD:00916 ! modified L-serine residue
-is_a: MOD:01164 ! riboflavin-phosphoryl
+is_a: MOD:01164 ! riboflavin-phosphorylated residue
 
 [Term]
 id: MOD:00356
-name: S-(4a-FMN)-L-cysteine
+name: S-(4alpha-FMN)-L-cysteine
 def: "A protein modification that effectively converts an L-cysteine residue to S-(4a-FMN)-L-cysteine." [PubMed:12668455, PubMed:12846567, PubMed:7692961, RESID:AA0351, Unimod:443#C]
 subset: PSI-MOD-slim
 synonym: "(R)-2-amino-3-(4a-riboflavin 5'-dihydrogen phosphate)sulfanylpropanoic acid" EXACT RESID-systematic []
@@ -9042,7 +9038,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:443"
 xref: UniProt: "PTM-0270"
-is_a: MOD:00896 ! FMN modified residue
+is_a: MOD:02083 ! 4alpha-FMN modified residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -9071,7 +9067,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:409"
 xref: UniProt: "PTM-0289"
-is_a: MOD:00896 ! FMN modified residue
+is_a: MOD:02085 ! 8alpha-FMN modified residue
 is_a: MOD:00909 ! modified L-histidine residue
 
 [Term]
@@ -9099,7 +9095,7 @@ xref: Origin: "H"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:409"
-is_a: MOD:00896 ! FMN modified residue
+is_a: MOD:02085 ! 8alpha-FMN modified residue
 is_a: MOD:00909 ! modified L-histidine residue
 
 [Term]
@@ -9391,8 +9387,8 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:1"
 xref: UniProt: "PTM-0232"
-is_a: MOD:00644 ! O-acetylated residue
-is_a: MOD:00647 ! acetylated L-serine
+is_a: MOD:00644 ! mono O-acetylated residue
+is_a: MOD:00647 ! monoacetylated L-serine
 is_a: MOD:02003 ! O3-acylated L-serine
 
 [Term]
@@ -9808,6 +9804,7 @@ xref: UniProt: "PTM-0046"
 is_a: MOD:02042 ! crosslinked L-asparagine residue
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:01882 ! 5-imidazolinone ring crosslinked residues (Gly)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:00386
@@ -9835,6 +9832,7 @@ xref: UniProt: "PTM-0048"
 is_a: MOD:02047 ! crosslinked glycine residue
 is_a: MOD:02051 ! crosslinked L-lysine residue
 is_a: MOD:01882 ! 5-imidazolinone ring crosslinked residues (Gly)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:00387
@@ -9994,14 +9992,14 @@ is_a: MOD:00427 ! methylated residue
 
 [Term]
 id: MOD:00394
-name: acetylated residue
-def: "A protein modification that effectively replaces a hydrogen atom with an acetyl group." [DeltaMass:0, PubMed:11857757, PubMed:11999733, PubMed:12175151, PubMed:14730666, PubMed:15350136, Unimod:1]
+name: monoacetylated residue
+def: "A protein modification that effectively replaces one hydrogen atom with one acetyl group." [DeltaMass:0, PubMed:11857757, PubMed:11999733, PubMed:12175151, PubMed:14730666, PubMed:15350136, Unimod:1]
 comment: Amino hydrogens are replaced to produce amides; hydroxyl hydrogens are replaced to produce esters; and hydrosulfanyl (thiol) hydrogens are replaced to produce sulfanyl esters (thiol esters). From DeltaMass: Average Mass: 42
 subset: PSI-MOD-slim
 synonym: "Acetyl" RELATED PSI-MS-label []
 synonym: "Acetylation" RELATED Unimod-description []
 synonym: "Acetylation (N terminus, N epsilon of Lysine, O of Serine) (Ac)" EXACT DeltaMass-label []
-synonym: "AcRes" EXACT PSI-MOD-label []
+synonym: "Ac1Res" EXACT PSI-MOD-label []
 xref: DiffAvg: "42.04"
 xref: DiffFormula: "C 2 H 2 O 1"
 xref: DiffMono: "42.010565"
@@ -10012,7 +10010,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:1"
-is_a: MOD:00649 ! acylated residue
+is_a: MOD:02078 ! acetylated residue
 
 [Term]
 id: MOD:00395
@@ -10256,7 +10254,7 @@ is_obsolete: true
 
 [Term]
 id: MOD:00408
-name: N-acetylated residue
+name: mono N-acetylated residue
 def: "A protein modification that effectively replaces a residue amino or imino hydrogen with an acetyl group." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "N-Acetyl" EXACT PSI-MOD-alternate []
@@ -10271,7 +10269,7 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00394 ! acetylated residue
+is_a: MOD:00394 ! monoacetylated residue
 is_a: MOD:00670 ! N-acylated residue
 
 [Term]
@@ -10721,7 +10719,7 @@ is_a: MOD:00431 ! modified residue with a secondary neutral loss
 
 [Term]
 id: MOD:00433
-name: glucosylated residue
+name: monoglucosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom with an glucose group through a glycosidic bond." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "GlcRes" EXACT PSI-MOD-label []
@@ -10734,8 +10732,8 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00434 ! hexosylated residue
-is_a: MOD:00726 ! glucosylated
+is_a: MOD:00761 ! monohexosylated residue
+is_a: MOD:00726 ! glucosylated residue
 
 [Term]
 id: MOD:00434
@@ -11024,7 +11022,7 @@ is_a: MOD:00764 ! glycoconjugated residue
 
 [Term]
 id: MOD:00448
-name: N-acetylaminoglucosylated residue
+name: mono-N-acetylaminoglucosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom with an N-acetylaminoglucose group through a glycosidic bond." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "GlcNAcRes" EXACT PSI-MOD-label []
@@ -11104,11 +11102,14 @@ xref: DiffMono: "59.036279"
 xref: Formula: "(12)C 6 (13)C 3 H 16 N 2 O 2"
 xref: MassAvg: "187.13"
 xref: MassMono: "187.131242"
-xref: Origin: "K"
+xref: Origin: "X"
 xref: Source: "artifact"
-xref: TermSpec: "none"
+xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:59"
-is_a: MOD:00451 ! alpha-amino propanoylated residue
+relationship: derives_from MOD:00451 ! alpha-amino propanoylated residue
+is_a: MOD:01428 ! (13)C isotope tagged reagent
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+
 
 [Term]
 id: MOD:00453
@@ -11184,11 +11185,11 @@ is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:00457
-name: alpha-amino succinylated residue
-def: "A protein modification that effectively replaces a residue alpha-amino- or alpha-imino-hydrogen with a succinyl group." [PubMed:11857757, PubMed:12175151, Unimod:64#N-term]
+name: 4x(12)C, 4x(1)H labeled alpha-amino succinylated residue
+def: "A protein modification that effectively replaces a residue alpha-amino- or alpha-imino-hydrogen with a light succinyl group." [PubMed:11857757, PubMed:12175151, Unimod:64#N-term]
 synonym: "Succinic anhydride labeling reagent light form (N-term)" RELATED Unimod-description []
 synonym: "Succinyl" RELATED PSI-MS-label []
-xref: DiffAvg: "100.02"
+xref: DiffAvg: "100.03"
 xref: DiffFormula: "(12)C 4 (1)H 4 O 3"
 xref: DiffMono: "100.016044"
 xref: Formula: "none"
@@ -11198,9 +11199,9 @@ xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:64"
-is_a: MOD:00848 ! reagent derivatized residue
-is_a: MOD:01029 ! succinylated residue
+relationship: derives_from MOD:01029 ! succinylated residue
 is_a: MOD:01696 ! alpha-amino acylated residue
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:00458
@@ -11218,7 +11219,9 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:65"
-is_a: MOD:00457 ! alpha-amino succinylated residue
+relationship: derives_from MOD:01029 ! succinylated residue
+is_a: MOD:01696 ! alpha-amino acylated residue
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:00459
@@ -11235,7 +11238,10 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:66"
-is_a: MOD:00457 ! alpha-amino succinylated residue
+relationship: derives_from MOD:01029 ! succinylated residue
+is_a: MOD:01696 ! alpha-amino acylated residue
+is_a: MOD:01428 ! (13)C isotope tagged reagent
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:00460
@@ -11272,7 +11278,7 @@ is_a: MOD:00708 ! sulfur oxygenated L-cysteine
 
 [Term]
 id: MOD:00461
-name: nitrosylation
+name: nitrated residue
 def: "A protein modification that effectively substitutes a nitrite (NO2) group for a hydrogen atom." [DeltaMass:0, PubMed:8839040, PubMed:9252331, Unimod:354]
 comment: Note, this is often misrepresented as the introduction of a nitrate (NO3) group [JSG].
 subset: PSI-MOD-slim
@@ -11531,7 +11537,7 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:97"
-is_a: MOD:00417 ! S-carboxamidoethyl-L-cysteine
+relationship: derives_from MOD:00417 ! S-carboxamidoethyl-L-cysteine
 is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
@@ -11555,12 +11561,21 @@ is_a: MOD:02039 ! aminated residue
 
 [Term]
 id: MOD:00476
-name: galactosylated residue
+name: monogalactosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom with an galactose group through a glycosidic bond." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "GalRes" EXACT PSI-MOD-label []
-is_a: MOD:00434 ! hexosylated residue
-is_a: MOD:00728 ! galactosylated
+xref: DiffAvg: "162.14"
+xref: DiffFormula: "C 6 H 10 O 5"
+xref: DiffMono: "162.052823"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+is_a: MOD:00761 ! monohexosylated residue
+is_a: MOD:00728 ! galactosylated residue
 
 [Term]
 id: MOD:00477
@@ -11581,7 +11596,6 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:360"
 is_a: MOD:00683 ! dehydrogenated residue
 is_a: MOD:00915 ! modified L-proline residue
-is_a: MOD:00960 ! decarboxylated residue
 
 [Term]
 id: MOD:00478
@@ -11671,7 +11685,7 @@ is_a: MOD:01428 ! (13)C isotope tagged reagent
 [Term]
 id: MOD:00482
 name: N-formyl-L-methionine (Met)
-def: "A protein modification that effectively converts an L-methionine residue to N-formyl-L-methionine (not known as a natural, post-translational modification process)." [PubMed:11152118, PubMed:2165784, PubMed:3042771, RESID:AA0021#MET]
+def: "A protein modification that effectively converts an L-methionine residue to N-formyl-L-methionine (not known as a natural, post-translational modification process)." [PubMed:11152118, PubMed:2165784, PubMed:3042771, Unimod:122#M, RESID:AA0021#MET]
 comment: This entry is for the artifactual formation of N-formyl-L-methionine from methionine. For encoded N-formyl-L-methionine, use MOD:00030 [JSG].
 synonym: "(2S)-2-formylamino-4-(methylsulfanyl)butanoic acid" EXACT RESID-systematic []
 synonym: "2-formamido-4-(methylsulfanyl)butanoic acid" EXACT RESID-alternate []
@@ -11690,8 +11704,8 @@ xref: MassMono: "160.043225"
 xref: Origin: "M"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
+xref: Unimod: "Unimod:122"
 xref: UniProt: "PTM-0212"
-is_a: MOD:00030 ! N-formyl-L-methionine residue
 is_a: MOD:00913 ! modified L-methionine residue
 
 [Term]
@@ -12188,13 +12202,13 @@ is_obsolete: true
 [Term]
 id: MOD:00508
 name: ISD a-series (C-Term)
-def: "modification from Unimod Other" [PubMed:14588022, Unimod:140]
+def: "OBSOLETE because this is an ion type and is not a biological or chemical modification to a polypeptide, can be handled by PSI-MS CV term, MS:1001229" [PubMed:14588022, Unimod:140]
 comment: Virtual Modification for MS/MS of a-type ions, by decarboxylation of C-terminus as reaction inside the mass spectrometer.
 synonym: "a-type-ion" RELATED PSI-MS-label []
 synonym: "ISD a-series (C-Term)" RELATED Unimod-description []
-xref: DiffAvg: "-29.02"
-xref: DiffFormula: "C -1 H -1 O -1"
-xref: DiffMono: "-29.002740"
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
@@ -12202,7 +12216,8 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "C-term"
 xref: Unimod: "Unimod:140"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
+
 
 [Term]
 id: MOD:00509
@@ -12773,7 +12788,6 @@ xref: Origin: "T"
 xref: Source: "none"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:659"
-is_a: MOD:00010 ! L-alanine residue
 is_a: MOD:00917 ! modified L-threonine residue
 
 [Term]
@@ -12833,8 +12847,9 @@ xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:185"
-is_a: MOD:00540 ! 9x(13)C labeled residue
 is_a: MOD:00919 ! modified L-tyrosine residue
+is_a: MOD:00842 ! (13)C labeled residue
+relationship: derives_from MOD:00540 ! 9x(13)C labeled residue
 relationship: derives_from MOD:00048 ! O4'-phospho-L-tyrosine
 
 [Term]
@@ -12853,7 +12868,8 @@ xref: Origin: "R"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:186"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00902 ! modified L-arginine residue
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00543
@@ -12872,7 +12888,8 @@ xref: Origin: "R"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:187"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00902 ! modified L-arginine residue
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00544
@@ -12897,12 +12914,6 @@ is_a: MOD:00842 ! (13)C labeled residue
 id: MOD:00545
 name: deuterated dimethyl labeling (D)
 def: "OBSOLETE because redundant with MOD:00927. Remap to MOD:00927." [PubMed:14670044]
-xref: DiffAvg: "34.07"
-xref: DiffFormula: "C 2 (1)H -2 (2)H 6"
-xref: DiffMono: "34.068961"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
@@ -12932,7 +12943,7 @@ is_a: MOD:00847 ! (18)O disubstituted residue
 [Term]
 id: MOD:00547
 name: 6-aminoquinolyl-N-hydroxysuccinimidyl carbamate
-def: "modification from Unimod Chemical derivative" [PubMed:14997490, Unimod:194]
+def: "modification from Unimod Chemical derivative used for amino acid analysis" [PubMed:14997490, Unimod:194]
 synonym: "6-aminoquinolyl-N-hydroxysuccinimidyl carbamate" RELATED Unimod-description []
 synonym: "AccQTag" RELATED PSI-MS-label []
 xref: DiffAvg: "170.17"
@@ -12945,11 +12956,11 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:194"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00548
-name: APTA-d0
+name: APTA
 def: "modification from Unimod Chemical derivative" [PubMed:15283597, Unimod:195]
 comment: Derivatization of cysteine with 3-acrylamidopropyl)trimethylammonium chloride [JSG].
 synonym: "APTA-d0" RELATED Unimod-description []
@@ -12964,7 +12975,7 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:195"
-is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00549
@@ -13099,7 +13110,7 @@ is_obsolete: true
 [Term]
 id: MOD:00556
 name: acrolein addition +94
-def: "modification from Unimod Other" [Unimod:205]
+def: "OBSOLETE because this modification not supported by any literature that I can find[PMT]" [Unimod:205]
 synonym: "Acrolein addition +94" RELATED Unimod-description []
 synonym: "Delta:H(6)C(6)O(1)" RELATED PSI-MS-label []
 xref: DiffAvg: "94.11"
@@ -13112,12 +13123,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:205"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00557
 name: acrolein addition +56
-def: "modification from Unimod Other" [PubMed:10825247, PubMed:15541752, Unimod:206]
+def: "OBSOLETE because this modification not supported by the papers listed or any other that I can find[PMT]" [PubMed:10825247, PubMed:15541752, Unimod:206]
 synonym: "Acrolein addition +56" RELATED Unimod-description []
 synonym: "Delta:H(4)C(3)O(1)" RELATED PSI-MS-label []
 xref: DiffAvg: "56.06"
@@ -13130,12 +13141,12 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:206"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00558
 name: acrolein addition +38
-def: "modification from Unimod Other" [Unimod:207]
+def: "OBSOLETE because this modification not supported by any literature that I can find[PMT]" [Unimod:207]
 synonym: "Acrolein addition +38" RELATED Unimod-description []
 synonym: "Delta:H(2)C(3)" RELATED PSI-MS-label []
 xref: DiffAvg: "38.05"
@@ -13148,12 +13159,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:207"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00559
 name: acrolein addition +76
-def: "modification from Unimod Other" [Unimod:208]
+def: "OBSOLETE because this modification not supported by any literature that I can find[PMT]" [Unimod:208]
 synonym: "Acrolein addition +76" RELATED Unimod-description []
 synonym: "Delta:H(4)C(6)" RELATED PSI-MS-label []
 xref: DiffAvg: "76.10"
@@ -13166,12 +13177,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:208"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00560
 name: acrolein addition +112
-def: "modification from Unimod Other" [Unimod:209]
+def: "OBSOLETE because this modification not supported by any literature that I can find[PMT]" [Unimod:209]
 synonym: "Acrolein addition +112" RELATED Unimod-description []
 synonym: "Delta:H(8)C(6)O(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "112.13"
@@ -13184,11 +13195,11 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:209"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00561
-name: N-ethyl iodoacetamide-d0
+name: N-ethyl iodoacetamide-
 def: "modification from Unimod Isotopic label" [PubMed:12766232, Unimod:211]
 synonym: "N-ethyl iodoacetamide-d0" RELATED Unimod-description []
 synonym: "NEIAA" RELATED PSI-MS-label []
@@ -13202,7 +13213,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:211"
-is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00562
@@ -13224,7 +13235,7 @@ is_a: MOD:01431 ! (2)H deuterium tagged reagent
 
 [Term]
 id: MOD:00563
-name: N-acetylaminogalactosylated residue
+name: mono-N-acetylaminogalactosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom with an N-acetylaminogalactose group through a glycosidic bond." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "GalNAcRes" EXACT PSI-MOD-label []
@@ -13247,12 +13258,6 @@ name: Applied Biosystems iTRAQ(TM) multiplexed quantitation chemistry
 def: "Modification from Unimod Isotopic label. The Unimod term was extracted when it had not been approved. OBSOLETE because redundant to MOD:01505. Remap to MOD:01505, or one of the child terms MOD:01493 or MOD:01497." [Unimod:214, URL:http\://docs.appliedbiosystems.com/pebiodocs/04351918.pdf]
 synonym: "iTRAQ4plex" RELATED Unimod-interim []
 synonym: "Representative mass and accurate mass for 116 & 117" RELATED Unimod-description []
-xref: DiffAvg: "144.10"
-xref: DiffFormula: "(12)C 4 (13)C 3 H 12 (14)N 1 (15)N 1 O 1"
-xref: DiffMono: "144.102062"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
@@ -13296,7 +13301,8 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:243"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00905 ! modified L-cysteine residue
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00567
@@ -13384,7 +13390,8 @@ xref: Origin: "R"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:343"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
+is_a: MOD:00902 ! modified L-arginine residue
 
 [Term]
 id: MOD:00573
@@ -13403,7 +13410,8 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:353"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
+is_a: MOD:00912 ! modified L-lysine residue
 
 [Term]
 id: MOD:00574
@@ -13422,7 +13430,8 @@ xref: Origin: "P"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:357"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
+is_a: MOD:00915 ! modified L-proline residue
 
 [Term]
 id: MOD:00575
@@ -13441,12 +13450,13 @@ xref: Origin: "T"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:361"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
+is_a: MOD:00917 ! modified L-threonine residue
 
 [Term]
 id: MOD:00576
-name: crotonaldehyde
-def: "modification from Unimod Other" [PubMed:11283024, Unimod:253]
+name: crotonylated residue
+def: "modification from Unimod Other" [PubMed:11283024, PubMed:25907603, Unimod:253]
 synonym: "Crotonaldehyde" RELATED PSI-MS-label []
 synonym: "Crotonaldehyde" RELATED Unimod-description []
 xref: DiffAvg: "70.09"
@@ -13459,48 +13469,49 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:253"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00649 ! acylated residue
 
 [Term]
 id: MOD:00577
-name: acetaldehyde +26
-def: "modification from Unimod Other" [PubMed:7744761, Unimod:254]
+name: acetaldehyde crosslinked penta-L-lysine
+def: "modification occurs as a Schiff base in the presence of pentalysine" [PubMed:7744761, Unimod:254]
 synonym: "Acetaldehyde +26" RELATED Unimod-description []
 synonym: "Delta:H(2)C(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "26.04"
 xref: DiffFormula: "C 2 H 2"
 xref: DiffMono: "26.015650"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
-xref: Origin: "X"
+xref: Formula: "C 8 H 14 N 2 O 1"
+xref: MassAvg: "666.91"
+xref: MassMono: "666.490465"
+xref: Origin: "K, K, K, K, K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:254"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:02051 ! crosslinked L-lysine residue
+is_a: MOD:00692 ! uncategorized crosslinked residues
 
 [Term]
 id: MOD:00578
 name: acetaldehyde +28
-def: "modification from Unimod Other" [Unimod:255]
+def: "OBSOLETE because this modification not supported by any literature that I can find [PMT]" [Unimod:255]
 synonym: "Acetaldehyde +28" RELATED Unimod-description []
 synonym: "Delta:H(4)C(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "28.05"
 xref: DiffFormula: "C 2 H 4"
 xref: DiffMono: "28.031300"
-xref: Formula: "none"
+xref: Formula: "C "
 xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:255"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00579
 name: propionaldehyde +40
-def: "modification from Unimod Other" [Unimod:256]
+def: "OBSOLETE because not supported by the linked literature [PMT]. modification from Unimod Other" [Unimod:256]
 synonym: "Delta:H(4)C(3)" RELATED PSI-MS-label []
 synonym: "Propionaldehyde +40" RELATED Unimod-description []
 xref: DiffAvg: "40.06"
@@ -13513,7 +13524,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:256"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00580
@@ -13631,7 +13642,7 @@ is_a: MOD:00786 ! deuterium substituted residue
 
 [Term]
 id: MOD:00586
-name: phosphorylation to pyridyl thiol
+name: pyridyl thiol modified residue
 def: "modification from Unimod Chemical derivative" [Unimod:264]
 synonym: "PET" RELATED PSI-MS-label []
 synonym: "phosphorylation to pyridyl thiol" RELATED Unimod-description []
@@ -13645,7 +13656,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:264"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00587
@@ -13690,7 +13701,7 @@ is_a: MOD:01809 ! 5x(13)C,1x(15)N labeled residue
 
 [Term]
 id: MOD:00589
-name: 1x(13)C,1x(15)N labeled L-phenylalanine
+name: 9x(13)C,1x(15)N labeled L-phenylalanine
 def: "A protein modification that effectively converts an L-phenylalanine residue to (13)C,(15)N labeled L-phenylalanine." [PubMed:12771378, Unimod:269]
 synonym: "13C(9) 15N(1) Silac label" RELATED Unimod-description []
 synonym: "Label:13C(9)15N(1)" RELATED PSI-MS-label []
@@ -13711,7 +13722,7 @@ is_a: MOD:00914 ! modified L-phenylalanine residue
 [Term]
 id: MOD:00590
 name: nucleophilic addtion to cytopiloyne
-def: "modification from Unimod Chemical derivative" [PubMed:15549660, Unimod:270]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative" [PubMed:15549660, Unimod:270]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -13724,12 +13735,12 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00591
 name: nucleophilic addition to cytopiloyne+H2O
-def: "modification from Unimod Chemical derivative" [PubMed:15549660, Unimod:271]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative" [PubMed:15549660, Unimod:271]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -13742,7 +13753,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00592
@@ -13760,12 +13771,12 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:272"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00593
 name: covalent modification of lysine by omega-maleimido alkanoyl N-hydroxysuccinimido esters
-def: "modification from Unimod Chemical derivative" [Unimod:273]
+def: "OBSOLETE because removed from Unimod. modification from Unimod Chemical derivative" [Unimod:273]
 comment: J. Prot. Chem. 2, 263-277, 1983
 synonym: "covalent modification of lysine by cross-linking reagent" RELATED Unimod-description []
 synonym: "Xlink:SSD" RELATED PSI-MS-label []
@@ -13779,7 +13790,7 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:273"
-is_a: MOD:00003 ! Unimod
+is_obsolete: true
 
 [Term]
 id: MOD:00594
@@ -13791,21 +13802,21 @@ is_a: MOD:00624 ! residues isobaric at 113.0-113.1 Da
 
 [Term]
 id: MOD:00595
-name: mannosylated residue
+name: monomannosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom with an manose group through a glycosidic bond" [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "ManRes" EXACT PSI-MOD-label []
 xref: DiffAvg: "162.14"
-xref: DiffFormula: "C 6 H 10 N 0 O 5"
+xref: DiffFormula: "C 6 H 10 O 5"
 xref: DiffMono: "162.052823"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "X"
-xref: Source: "none"
+xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00434 ! hexosylated residue
-is_a: MOD:00727 ! mannosylated
+is_a: MOD:00727 ! mannosylated residue
+is_a: MOD:00761 ! monohexosylated residue
 
 [Term]
 id: MOD:00596
@@ -13934,7 +13945,7 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
-xref: Remap: "MOD:00110"
+xref: Remap: "MOD:00600"
 xref: Unimod: "Unimod:283"
 is_obsolete: true
 
@@ -13964,8 +13975,8 @@ name: Sulfanilic Acid (SA), light C12
 def: "modification from Unimod Chemical derivative, C-Terminal/Glutamate/Aspartate sulfonation" [Unimod:285]
 synonym: "Light Sulfanilic Acid (SA) C12" RELATED Unimod-description []
 synonym: "SulfanilicAcid" RELATED PSI-MS-label []
-xref: DiffAvg: "155.17"
-xref: DiffFormula: "C 6 H 5 N 1 O 2 S 1"
+xref: DiffAvg: "155.00"
+xref: DiffFormula: "(12)C 6 H 5 N 1 O 2 S 1"
 xref: DiffMono: "155.004099"
 xref: Formula: "none"
 xref: MassAvg: "none"
@@ -13992,7 +14003,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "C-term"
 xref: Unimod: "Unimod:286"
-is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:01428 ! (13)C isotope tagged reagent
 
 [Term]
 id: MOD:00607
@@ -14019,9 +14030,9 @@ name: biotin polyethyleneoxide amine
 def: "modification from Unimod Chemical derivative" [Unimod:289]
 synonym: "Biotin polyethyleneoxide amine" RELATED Unimod-description []
 synonym: "Biotin-PEO-Amine" RELATED Unimod-interim []
-xref: DiffAvg: "356.49"
-xref: DiffFormula: "C 16 H 28 N 4 O 3 S 1"
-xref: DiffMono: "356.188212"
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
@@ -14029,11 +14040,11 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:289"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00609
-name: Pierce EZ-Link Biotin-HPDP
+name: Pierce EZ-Link Biotin-HPDP modified L-cysteine
 def: "modification from Unimod Chemical derivative" [Unimod:290]
 synonym: "Biotin-HPDP" RELATED Unimod-interim []
 synonym: "Pierce EZ-Link Biotin-HPDP" RELATED Unimod-description []
@@ -14047,7 +14058,8 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:290"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00905 ! modified L-cysteine residue
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00610
@@ -14127,7 +14139,7 @@ is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
 id: MOD:00614
-name: fucosylated
+name: fucosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a fucose (6-deoxy-D-galactose) group through a glycosidic bond." [PubMed:11344537, PubMed:15189151, Unimod:295]
 subset: PSI-MOD-slim
 synonym: "dHex" RELATED PSI-MS-label []
@@ -14144,7 +14156,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:295"
 xref: GNOme: "GNO:G49112ZN"
-is_a: MOD:00736 ! deoxyhexosylated
+is_a: MOD:00736 ! deoxyhexosylated residue
 
 [Term]
 id: MOD:00615
@@ -14332,7 +14344,7 @@ is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00626
-name: fluorescein-5-thiosemicarbazide
+name: fluorescein-5-thiosemicarbazide modified residue
 def: "modification from Unimod Chemical derivative" [PubMed:2883911, Unimod:478]
 synonym: "fluorescein-5-thiosemicarbazide" RELATED Unimod-description []
 synonym: "FTC" RELATED PSI-MS-label []
@@ -14498,7 +14510,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:324"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00635
@@ -14674,11 +14686,11 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:337"
-is_a: MOD:00003 ! Unimod
+is_a: MOD:00848 ! reagent derivatized residue
 
 [Term]
 id: MOD:00644
-name: O-acetylated residue
+name: mono O-acetylated residue
 def: "A protein modification that effectively replaces a residue hydroxyl group with an acetoxy group." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "OAcRes" EXACT PSI-MOD-label []
@@ -14691,12 +14703,12 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00394 ! acetylated residue
+is_a: MOD:00394 ! monoacetylated residue
 is_a: MOD:00671 ! O-acylated residue
 
 [Term]
 id: MOD:00645
-name: S-acetylated residue
+name: mono S-acetylated residue
 def: "A protein modification that effectively replaces a residue sulfanyl group with an acetylsulfanyl group." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "SAcRes" EXACT PSI-MOD-label []
@@ -14709,12 +14721,12 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00394 ! acetylated residue
+is_a: MOD:00394 ! monoacetylated residue
 is_a: MOD:00672 ! S-acylated residue
 
 [Term]
 id: MOD:00646
-name: acetylated L-cysteine
+name: monoacetylated L-cysteine
 def: "A protein modification that effectively converts an L-cysteine residue to either N-acetyl-L-cysteine or S-acetyl-L-cysteine." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "AcCys" EXACT PSI-MOD-label []
@@ -14726,12 +14738,12 @@ xref: MassAvg: "145.18"
 xref: MassMono: "145.019749"
 xref: Origin: "C"
 xref: Source: "natural"
-is_a: MOD:00394 ! acetylated residue
+is_a: MOD:00394 ! monoacetylated residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
 id: MOD:00647
-name: acetylated L-serine
+name: monoacetylated L-serine
 def: "A protein modification that effectively converts an L-serine residue to either N-acetyl-L-serine, O-acetyl-L-serine, or N,O-diacetyl-L-serine." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "AcSer" EXACT PSI-MOD-label []
@@ -14743,14 +14755,14 @@ xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "S"
 xref: Source: "natural"
-is_a: MOD:00394 ! acetylated residue
+is_a: MOD:00394 ! monoacetylated residue
 is_a: MOD:00916 ! modified L-serine residue
 
 [Term]
 id: MOD:00648
 name: N,O-diacetylated L-serine
 def: "A protein modification that effectively converts an L-serine residue to N,O-diacetyl-L-serine." [PubMed:16731519, PubMed:489587, PubMed:7309355, RESID:AA0051#var, RESID:AA0364#var]
-comment: The samples were prepared using glacial acetic acid, and were probably artifactual [JSG].
+comment: In one paper, the samples were prepared using glacial acetic acid, and were probably artifactual [JSG].
 synonym: "(S)-2-acetamido-3-acetyloxypropanoic acid" EXACT PSI-MOD-alternate []
 synonym: "N,O-diacetyl-L-serine" EXACT PSI-MOD-alternate []
 synonym: "N,O-diacetylserine" EXACT PSI-MOD-alternate []
@@ -14764,10 +14776,7 @@ xref: MassMono: "172.060983"
 xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
-is_a: MOD:00408 ! N-acetylated residue
-is_a: MOD:00644 ! O-acetylated residue
-is_a: MOD:02003 ! O3-acylated L-serine
-is_a: MOD:00647 ! acetylated L-serine
+is_a: MOD:02080 ! diacetylated L-serine
 relationship: has_functional_parent MOD:00060 ! N-acetyl-L-serine
 relationship: has_functional_parent MOD:00369 ! O-acetyl-L-serine
 
@@ -15254,7 +15263,6 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:7"
 xref: UniProt: "PTM-0116"
-is_a: MOD:00013 ! L-aspartic acid residue
 is_a: MOD:00400 ! deamidated residue
 is_a: MOD:00903 ! modified L-asparagine residue
 
@@ -15283,8 +15291,8 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:7"
 xref: UniProt: "PTM-0117"
-is_a: MOD:00015 ! L-glutamic acid residue
 is_a: MOD:00400 ! deamidated residue
+is_a: MOD:00907 ! modified L-glutamine residue
 
 [Term]
 id: MOD:00686
@@ -15310,7 +15318,6 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:162"
 is_a: MOD:00007 ! selenium substitution for sulfur
-is_a: MOD:00031 ! L-selenocysteine residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -15418,21 +15425,20 @@ is_a: MOD:00861 ! phosphorus containing modified residue
 [Term]
 id: MOD:00697
 name: flavin modified residue
-def: "A protein modification that effectively results from forming an adduct with a compound containing a flavin group." [Unimod:50]
+def: "A protein modification that effectively results from forming an adduct with a compound containing a flavin group." []
 subset: PSI-MOD-slim
 synonym: "FAD" RELATED PSI-MS-label []
 synonym: "Flavin adenine dinucleotide" RELATED Unimod-description []
 synonym: "FlavRes" EXACT PSI-MOD-label []
-xref: DiffAvg: "783.54"
-xref: DiffFormula: "C 27 H 31 N 9 O 15 P 2 S 0"
-xref: DiffMono: "783.141485"
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
-xref: Unimod: "Unimod:50"
 is_a: MOD:01156 ! protein modification categorized by chemical process
 
 [Term]
@@ -15609,7 +15615,7 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00430 ! trimethylated residue
+is_a: MOD:00427 ! methylated residue
 
 [Term]
 id: MOD:00712
@@ -15796,7 +15802,7 @@ xref: MassMono: "171.113353"
 xref: Origin: "K"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00408 ! N-acetylated residue
+is_a: MOD:00408 ! mono N-acetylated residue
 is_a: MOD:00912 ! modified L-lysine residue
 
 [Term]
@@ -15829,28 +15835,29 @@ is_a: MOD:00693 ! glycosylated residue
 
 [Term]
 id: MOD:00726
-name: glucosylated
+name: glucosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a glucose group through a glycosidic bond." [PubMed:18688235]
 synonym: "Glc" EXACT PSI-MOD-label []
-xref: DiffAvg: "162.14"
-xref: DiffFormula: "C 6 H 10 O 5"
-xref: DiffMono: "162.052823"
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
+xref: Remap: "MOD:00433"
 is_a: MOD:00693 ! glycosylated residue
 
 [Term]
 id: MOD:00727
-name: mannosylated
+name: mannosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a mannose group through a glycosidic bond," [PubMed:18688235]
 synonym: "Man" EXACT PSI-MOD-label []
-xref: DiffAvg: "162.14"
-xref: DiffFormula: "C 6 H 10 O 5"
-xref: DiffMono: "162.052823"
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
@@ -15861,12 +15868,12 @@ is_a: MOD:00693 ! glycosylated residue
 
 [Term]
 id: MOD:00728
-name: galactosylated
+name: galactosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a galactose group through a glycosidic bond." [PubMed:18688235]
 synonym: "Gal" EXACT PSI-MOD-label []
-xref: DiffAvg: "162.14"
-xref: DiffFormula: "C 6 H 10 O 5"
-xref: DiffMono: "162.052823"
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
 xref: Formula: "none"
 xref: MassAvg: "none"
 xref: MassMono: "none"
@@ -15896,7 +15903,7 @@ is_a: MOD:00693 ! glycosylated residue
 
 [Term]
 id: MOD:00730
-name: arabinosylated
+name: arabinosylated residue
 def: "a protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a arabinose sugar group through a glycosidic bond" [PubMed:18688235]
 synonym: "Ara" EXACT PSI-MOD-label []
 xref: DiffAvg: "132.12"
@@ -15912,7 +15919,7 @@ is_a: MOD:00729 ! pentosylated residue
 
 [Term]
 id: MOD:00731
-name: ribosylated
+name: ribosylated residue
 def: "a protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a ribose sugar group through a glycosidic bond" [PubMed:18688235]
 synonym: "Rib" EXACT PSI-MOD-label []
 xref: DiffAvg: "132.12"
@@ -15928,7 +15935,7 @@ is_a: MOD:00729 ! pentosylated residue
 
 [Term]
 id: MOD:00732
-name: xylosylated
+name: xylosylated residue
 def: "a protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a xylose sugar group through a glycosidic bond" [PubMed:18688235]
 synonym: "Xyl" EXACT PSI-MOD-label []
 xref: DiffAvg: "132.12"
@@ -15944,7 +15951,7 @@ is_a: MOD:00729 ! pentosylated residue
 
 [Term]
 id: MOD:00733
-name: N-acetylaminoglucosylated
+name: N-acetylaminoglucosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with an N-acetylglucosamine group through a glycosidic bond." [PubMed:18688235]
 synonym: "GlcNAc" EXACT PSI-MOD-label []
 xref: DiffAvg: "203.19"
@@ -15956,11 +15963,11 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00436 ! N-acetylhexosaminylated
+is_a: MOD:00436 ! N-acetylhexosaminylated residue
 
 [Term]
 id: MOD:00734
-name: N-acetylaminogalactosylated
+name: N-acetylaminogalactosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with an N-acetylgalactosamine group through a glycosidic bond." [DeltaMass:247]
 comment: From DeltaMass: Average Mass: 203 Formula:C8H13O5N1 Monoisotopic Mass Change:203.079 Average Mass Change:203.196 References:PE Sciex
 synonym: "GalNAc" EXACT PSI-MOD-label []
@@ -15974,11 +15981,11 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00436 ! N-acetylhexosaminylated
+is_a: MOD:00436 ! N-acetylhexosaminylated residue
 
 [Term]
 id: MOD:00735
-name: hexosuronylated
+name: hexosuronylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a hexosuronic acid group through a glycosidic bond." [PubMed:18688235]
 synonym: "HexA" EXACT PSI-MOD-label []
 xref: DiffAvg: "176.12"
@@ -15994,7 +16001,7 @@ is_a: MOD:00693 ! glycosylated residue
 
 [Term]
 id: MOD:00736
-name: deoxyhexosylated
+name: deoxyhexosylated residue
 def: "a protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with a deoxyhexose group through a glycosidic bond" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 146
 subset: PSI-MOD-slim
@@ -16014,7 +16021,7 @@ is_a: MOD:00693 ! glycosylated residue
 
 [Term]
 id: MOD:00737
-name: N-acetylneuraminylated
+name: N-acetylneuraminylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with an N-acetylneuraminic acid (sialic acid) group through a glycosidic bond." [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 291
 synonym: "N-acetylneuraminic acid (Sialic acid, NeuAc, NANA, SA)" EXACT DeltaMass-label []
@@ -16139,12 +16146,12 @@ is_a: MOD:00701 ! nucleotide or nucleic acid modified residue
 
 [Term]
 id: MOD:00752
-name: adenosine diphosphoribosyl (ADP-ribosyl) modified residue
-def: "A protein modification that effectively results from forming an adduct with ADP-ribose through formation of a glycosidic bond." [DeltaMass:0]
+name: monoadenosine diphosphoribosyl (ADP-ribosyl) modified residue
+def: "A protein modification that effectively results from forming an adduct with one ADP-ribose through formation of a glycosidic bond." [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 541.
 subset: PSI-MOD-slim
 synonym: "ADP-rybosylation (from NAD)" EXACT DeltaMass-label []
-synonym: "ADPRibRes" EXACT PSI-MOD-label []
+synonym: "ADPRib1Res" EXACT PSI-MOD-label []
 xref: DiffAvg: "541.30"
 xref: DiffFormula: "C 15 H 21 N 5 O 13 P 2"
 xref: DiffMono: "541.061109"
@@ -16154,7 +16161,7 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00701 ! nucleotide or nucleic acid modified residue
+is_a: MOD:02087 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
 
 [Term]
 id: MOD:00753
@@ -16257,7 +16264,6 @@ xref: Origin: "P"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0578"
-is_a: MOD:00448 ! N-acetylaminoglucosylated residue
 is_a: MOD:01677 ! O4-(N-acetylamino)hexosyl-L-hydroxyproline
 
 [Term]
@@ -16302,7 +16308,7 @@ is_a: MOD:00160 ! N4-glycosyl-L-asparagine
 
 [Term]
 id: MOD:00761
-name: monohexosylated (Hex1)
+name: monohexosylated residue
 def: "A protein modification that effectively replaces a hydrogen atom of an amino acid residue or of a modifying group with one hexose sugar group through a glycosidic bond." [PubMed:18688235]
 synonym: "Hex1" EXACT PSI-MOD-alternate []
 xref: DiffAvg: "162.14"
@@ -16403,7 +16409,7 @@ is_a: MOD:01862 ! disulfide conjugated residue
 [Term]
 id: MOD:00766
 name: C terminal -K from HC of MAb
-def: "modification from Unimod Post-translational - C-terminal loss of lysine" [PubMed:16078144, Unimod:313]
+def: "modification from Unimod Post-translational - C-terminal loss of lysine OBSOLETE because the idenical to MOD:01642. Remap to MOD:01642" [PubMed:16078144, Unimod:313]
 synonym: "Loss of C-terminal K from Heavy Chain of MAb" RELATED Unimod-description []
 synonym: "Lys-loss" RELATED PSI-MS-label []
 xref: DiffAvg: "-128.18"
@@ -16415,7 +16421,8 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: TermSpec: "C-term"
 xref: Unimod: "Unimod:313"
-is_a: MOD:00003 ! Unimod
+xref: Remap: "MOD:01642"
+is_obsolete: true
 
 [Term]
 id: MOD:00767
@@ -16499,8 +16506,8 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:348"
-is_a: MOD:00012 ! L-asparagine residue
 is_a: MOD:00909 ! modified L-histidine residue
+is_a: MOD:02088 ! natural, standard, encoded residue substitution
 
 [Term]
 id: MOD:00776
@@ -16520,8 +16527,8 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:349"
-is_a: MOD:00013 ! L-aspartic acid residue
 is_a: MOD:00909 ! modified L-histidine residue
+is_a: MOD:02088 ! natural, standard, encoded residue substitution
 
 [Term]
 id: MOD:00777
@@ -16732,7 +16739,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:364"
-is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:01428 ! (13)C isotope tagged reagent
 
 [Term]
 id: MOD:00790
@@ -16769,7 +16776,7 @@ xref: Origin: "Q"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:366"
-is_a: MOD:00685 ! deamidated L-glutamine
+relationship: derives_from MOD:00685 ! deamidated L-glutamine
 is_a: MOD:00852 ! 1x(18)O labeled deamidated residue
 
 [Term]
@@ -16939,8 +16946,7 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0624"
 is_a: MOD:00426 ! S-glycosylated residue
-is_a: MOD:00476 ! galactosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00476 ! monogalactosylated residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -17063,8 +17069,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0573"
 is_a: MOD:00002 ! O-glycosyl-L-serine
-is_a: MOD:00433 ! glucosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00433 ! monoglucosylated residue
 
 [Term]
 id: MOD:00805
@@ -17093,7 +17098,7 @@ xref: Origin: "S"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0580"
-is_a: MOD:00448 ! N-acetylaminoglucosylated residue
+is_a: MOD:00448 ! mono-N-acetylaminoglucosylated residue
 is_a: MOD:01675 ! O-(N-acetylamino)hexosyl-L-serine
 
 [Term]
@@ -17123,7 +17128,7 @@ xref: Origin: "T"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0582"
-is_a: MOD:00448 ! N-acetylaminoglucosylated residue
+is_a: MOD:00448 ! mono-N-acetylaminoglucosylated residue
 is_a: MOD:01676 ! O-(N-acetylamino)hexosyl-L-threonine
 
 [Term]
@@ -17174,8 +17179,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0560"
 is_a: MOD:00002 ! O-glycosyl-L-serine
-is_a: MOD:00476 ! galactosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00476 ! monogalactosylated residue
 
 [Term]
 id: MOD:00809
@@ -17198,8 +17202,7 @@ xref: Origin: "T"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0562"
-is_a: MOD:00476 ! galactosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00476 ! monogalactosylated residue
 is_a: MOD:01348 ! O-hexosylated threonine
 
 [Term]
@@ -17225,8 +17228,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0588"
 is_a: MOD:00002 ! O-glycosyl-L-serine
-is_a: MOD:00595 ! mannosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00595 ! monomannosylated residue
 
 [Term]
 id: MOD:00811
@@ -17249,8 +17251,7 @@ xref: Origin: "T"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0591"
-is_a: MOD:00595 ! mannosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00595 ! monomannosylated residue
 is_a: MOD:01348 ! O-hexosylated threonine
 
 [Term]
@@ -17280,7 +17281,7 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:295"
 xref: UniProt: "PTM-0550"
 is_a: MOD:00002 ! O-glycosyl-L-serine
-is_a: MOD:00614 ! fucosylated
+is_a: MOD:00614 ! fucosylated residue
 
 [Term]
 id: MOD:00813
@@ -17308,7 +17309,7 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:295"
 xref: UniProt: "PTM-0552"
 is_a: MOD:00005 ! O-glycosyl-L-threonine
-is_a: MOD:00614 ! fucosylated
+is_a: MOD:00614 ! fucosylated residue
 
 [Term]
 id: MOD:00814
@@ -17742,7 +17743,7 @@ xref: Origin: "N"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0527"
-is_a: MOD:00448 ! N-acetylaminoglucosylated residue
+is_a: MOD:00448 ! mono-N-acetylaminoglucosylated residue
 is_a: MOD:01674 ! N4-(N-acetylamino)hexosyl-L-asparagine
 
 [Term]
@@ -17770,7 +17771,7 @@ xref: Origin: "N"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0512"
-is_a: MOD:00563 ! N-acetylaminogalactosylated residue
+is_a: MOD:00563 ! mono-N-acetylaminogalactosylated residue
 is_a: MOD:01674 ! N4-(N-acetylamino)hexosyl-L-asparagine
 
 [Term]
@@ -17797,8 +17798,7 @@ xref: Origin: "N"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0517"
-is_a: MOD:00433 ! glucosylated residue
-is_a: MOD:00761 ! monohexosylated (Hex1)
+is_a: MOD:00433 ! monoglucosylated residue
 is_a: MOD:01346 ! N4-hexosylated asparagine
 
 [Term]
@@ -18269,7 +18269,6 @@ xref: MassMono: "251.947170"
 xref: Origin: "C, C"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00007 ! selenium substitution for sulfur
 is_a: MOD:01627 ! L-cysteinyl-L-selenocysteine
 
 [Term]
@@ -18305,8 +18304,8 @@ xref: Origin: "D"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0314"
-is_a: MOD:00010 ! L-alanine residue
 is_a: MOD:00904 ! modified L-aspartic acid residue
+is_a: MOD:02088 ! natural, standard, encoded residue substitution
 
 [Term]
 id: MOD:00870
@@ -18346,7 +18345,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:412"
-is_a: MOD:00870 ! phenyl isocyanate derivatized residue
+relationship: derives_from MOD:00870 ! phenyl isocyanate derivatized residue
 is_a: MOD:01431 ! (2)H deuterium tagged reagent
 
 [Term]
@@ -18514,7 +18513,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:464"
-is_a: MOD:00584 ! 4-sulfophenyl isothiocyanate derivatized residue
+relationship: derives_from MOD:00584 ! 4-sulfophenyl isothiocyanate derivatized residue
 is_a: MOD:01428 ! (13)C isotope tagged reagent
 
 [Term]
@@ -18668,8 +18667,11 @@ xref: Origin: "MOD:00888"
 xref: Source: "natural"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:36"
-is_a: MOD:00075 ! N,N-dimethyl-L-proline
+relationship: derives_from MOD:00075 ! N,N-dimethyl-L-proline
 relationship: derives_from MOD:00888 ! protonated L-proline (L-prolinium) residue
+is_a: MOD:00712 ! methylated proline
+is_a: MOD:00710 ! protonated-dimethylated residue
+is_a: MOD:01686 ! alpha-amino dimethylated residue
 
 [Term]
 id: MOD:00890
@@ -18753,6 +18755,16 @@ id: MOD:00895
 name: FAD modified residue
 def: "A protein modification that effectively results from forming an adduct with a compound containing a flavin adenine dinucleotide (FAD) group." [PubMed:18688235]
 subset: PSI-MOD-slim
+synonym: "FADRes" EXACT PSI-MOD-label []
+xref: DiffAvg: "783.54"
+xref: DiffFormula: "C 27 H 31 N 9 O 15 P 2"
+xref: DiffMono: "783.141485"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
 is_a: MOD:00697 ! flavin modified residue
 is_a: MOD:00861 ! phosphorus containing modified residue
 
@@ -18761,6 +18773,16 @@ id: MOD:00896
 name: FMN modified residue
 def: "A protein modification that effectively results from forming an adduct with a compound containing a riboflavin phosphate (flavin mononucleotide, FMN) group." [PubMed:18688235]
 subset: PSI-MOD-slim
+synonym: "FMNRes" EXACT PSI-MOD-label []
+xref: DiffAvg: "none"
+xref: DiffFormula: "none"
+xref: DiffMono: "none"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
 is_a: MOD:00697 ! flavin modified residue
 is_a: MOD:00861 ! phosphorus containing modified residue
 
@@ -19227,7 +19249,7 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:499"
 is_a: MOD:00905 ! modified L-cysteine residue
-is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:01428 ! (13)C isotope tagged reagent
 
 [Term]
 id: MOD:00933
@@ -19452,7 +19474,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:477"
-is_a: MOD:00943 ! 4-trimethylammoniumbutanoyl derivatized residue
+relationship: derives_from MOD:00943 ! 4-trimethylammoniumbutanoyl derivatized residue
 is_a: MOD:01431 ! (2)H deuterium tagged reagent
 
 [Term]
@@ -19487,7 +19509,7 @@ is_a: MOD:00032 ! uncategorized protein modification
 [Term]
 id: MOD:00948
 name: 5'-dephospho
-def: "modification from DeltaMass" [DeltaMass:0]
+def: "OBSOLETE because this is a modification that occurs to DNA/RNA and not proteins. modification from DeltaMass" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: -79
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -19498,7 +19520,7 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:00949
@@ -19520,7 +19542,7 @@ is_obsolete: true
 [Term]
 id: MOD:00950
 name: decomposed carboxymethylated methionine
-def: "modification from DeltaMass" [DeltaMass:3]
+def: "OBSOLETE because this modification has not been seen/reported on since this original publication in 1994 and carboxymethylation of proteins is common enough for this mass shift to have been seen in the intervening 25+ years. modification from DeltaMass" [DeltaMass:3]
 comment: From DeltaMass: Average Mass: -48 Average Mass Change:-48 References:Anal. Biochem. Vol 216 No.1 p141
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -19531,7 +19553,7 @@ xref: MassMono: "none"
 xref: Origin: "M"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:00951
@@ -19548,7 +19570,6 @@ xref: MassMono: "129.042593"
 xref: Origin: "E"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00015 ! L-glutamic acid residue
 is_a: MOD:00906 ! modified L-glutamic acid residue
 is_a: MOD:00957 ! modified residue with neutral loss of carbon dioxide
 is_a: MOD:00960 ! decarboxylated residue
@@ -19676,7 +19697,7 @@ xref: MassMono: "none"
 xref: Origin: "H, R"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_a: MOD:00692 ! uncategorized crosslinked residues
 
 [Term]
 id: MOD:00959
@@ -19832,7 +19853,7 @@ is_a: MOD:02051 ! crosslinked L-lysine residue
 [Term]
 id: MOD:00968
 name: CM-Cys vs PAM-Cys
-def: "modification from DeltaMass" [DeltaMass:347]
+def: "OBSOLETE because this isn't a protein modification, but rather the difference between two known modifications. modification from DeltaMass" [DeltaMass:347]
 comment: From DeltaMass: Average Mass: 13 Formula:C2H2O2 vs C3H5ON Monoisotopic Mass Change:13.03 Average Mass Change:13.05 Notes:Residual acrylamide in SDS gels can partly label cysteine residues in proteins (propionamido-Cys, PAM-Cys, DeltaMass +71Da; see entry). Subsequent alkylation of protein bands with iodoacetic acid e.g. in preparation for proteomic analysis, will convert remaining free cysteines into carboxymethyl-Cys (CM-Cys, DeltaMass +58Da; see entry). Peptide mass fingerprinting may therefore potentially reveal the same cysteine-containing peptide in two forms, differing in mass by 13Da. The relative ratios of the peaks will depend on the initial degree of labelling with acrylamide. Use of high quality, deionised acrylamide in the SDS gel will minimise modification of cysteine through this route. Where it remains a problem, deliberate alkylation using acrylamide instead of iodoacetamide will ensure chemical homogeneity of the final product.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -19843,12 +19864,12 @@ xref: MassMono: "none"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:00969
 name: CAM-Cys vs PAM-Cys
-def: "modification from DeltaMass" [DeltaMass:346]
+def: "OBSOLETE because this isn't a protein modification, but rather the difference between two known modifications. modification from DeltaMass" [DeltaMass:346]
 comment: From DeltaMass: Average Mass: 14 Formula:CH2 Monoisotopic Mass Change:14.016 Average Mass Change:14.027 Notes: Residual acrylamide in SDS gels can partly label cysteine residues in proteins (propionamido-Cys, PAM-Cys, DeltaMass +71Da; see entry). Subsequent alkylation of protein bands with iodoacetamide e.g. in preparation for proteomic analysis, will convert remaining free cysteines into carboxamidomethyl-Cys (CAM-Cys, DeltaMass +57Da; see entry). Peptide mass fingerprinting may therefore potentially reveal the same cysteine-containing peptide in two forms, differing in mass by 14Da. The relative ratios of the peaks will depend on the initial degree of labelling with acrylamide. Use of high quality, deionised acrylamide in the SDS gel will minimise modification of cysteine through this route. Where it remains a problem, deliberate alkylation using acrylamide instead of iodoacetamide will ensure chemical homogeneity of the final product.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -19859,7 +19880,7 @@ xref: MassMono: "none"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:00970
@@ -19879,19 +19900,20 @@ is_a: MOD:00947 ! DeltaMass
 
 [Term]
 id: MOD:00971
-name: Oxohistidine (from histidine)
-def: "modification from DeltaMass" [DeltaMass:38]
+name: 2-Oxohistidine
+def: "A protein modification that effectively converts an L-histidine residue to 2-oxohistidine." [PubMed:8405458, DeltaMass:38]
 comment: From DeltaMass: Average Mass: 16 Average Mass Change:16 References:Lewisch, S. A. and Levine, R. L. (1995) Anal. Biochem. 231, 440-446. Determination of 2-oxo-histidine by amino acid analysis Notes:Rod LevineNIHBldg 3, Room 106 MSC 0320Bethesda, MD 20892-0320email: rlevine@nih.govvoice: 1 (301) 496-2310fax: 1 (301) 496-0599
-xref: DiffAvg: "none"
-xref: DiffFormula: "none"
-xref: DiffMono: "none"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
+xref: DiffAvg: "16"
+xref: DiffFormula: "C 0 H 0 N 0 O 1"
+xref: DiffMono: "15.994915"
+xref: Formula: "C 6 H 7 N 3 O 2"
+xref: MassAvg: "153.14"
+xref: MassMono: "153.053826"
 xref: Origin: "H"
-xref: Source: "none"
+xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_a: MOD:00909 ! modified L-histidine residue
+is_a: MOD:00677 ! hydroxylated residue
 
 [Term]
 id: MOD:00972
@@ -19911,7 +19933,7 @@ xref: Origin: "F"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:340"
-is_a: MOD:01066 ! halogenated phenylalanine
+is_a: MOD:02086 ! brominated phenylalanine
 is_a: MOD:01912 ! monobrominated residue
 
 [Term]
@@ -19944,7 +19966,8 @@ xref: MassMono: "197.024356"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01046 ! 3'-chloro-L-tyrosine
+relationship: derives_from MOD:01046 ! 3'-chloro-L-tyrosine
+is_a: MOD:00987 ! chlorinated tyrosine
 
 [Term]
 id: MOD:00975
@@ -19960,7 +19983,8 @@ xref: MassMono: "199.021406"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01046 ! 3'-chloro-L-tyrosine
+relationship: derives_from MOD:01046 ! 3'-chloro-L-tyrosine
+is_a: MOD:00987 ! chlorinated tyrosine
 
 [Term]
 id: MOD:00976
@@ -20079,8 +20103,8 @@ xref: MassMono: "150.953635"
 xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00031 ! L-selenocysteine residue
 is_a: MOD:00916 ! modified L-serine residue
+is_a: MOD:02088 ! natural, standard, encoded residue substitution
 
 [Term]
 id: MOD:00983
@@ -20112,7 +20136,8 @@ xref: MassMono: "230.985384"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01045 ! 3',5'-dichloro-L-tyrosine
+relationship: derives_from MOD:01045 ! 3',5'-dichloro-L-tyrosine
+is_a: MOD:00987 ! chlorinated tyrosine
 
 [Term]
 id: MOD:00985
@@ -20140,7 +20165,8 @@ xref: MassMono: "232.982434"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01045 ! 3',5'-dichloro-L-tyrosine
+relationship: derives_from MOD:01045 ! 3',5'-dichloro-L-tyrosine
+is_a: MOD:00987 ! chlorinated tyrosine
 
 [Term]
 id: MOD:00987
@@ -20195,7 +20221,8 @@ xref: MassMono: "234.979484"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01045 ! 3',5'-dichloro-L-tyrosine
+relationship: derives_from MOD:01045 ! 3',5'-dichloro-L-tyrosine
+is_a: MOD:00987 ! chlorinated tyrosine
 
 [Term]
 id: MOD:00991
@@ -20260,7 +20287,8 @@ xref: MassMono: "240.973841"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01025 ! 3'-bromo-L-tyrosine
+relationship: derives_from MOD:01025 ! 3'-bromo-L-tyrosine
+is_a: MOD:01000 ! monobrominated tyrosine
 
 [Term]
 id: MOD:00995
@@ -20276,7 +20304,8 @@ xref: MassMono: "226.976879"
 xref: Origin: "F"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00183 ! L-2'-bromophenylalanine
+relationship: derives_from MOD:00183 ! L-2'-bromophenylalanine
+is_a: MOD:02086 ! brominated phenylalanine
 
 [Term]
 id: MOD:00996
@@ -20292,7 +20321,8 @@ xref: MassMono: "242.971794"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01025 ! 3'-bromo-L-tyrosine
+relationship: derives_from MOD:01025 ! 3'-bromo-L-tyrosine
+is_a: MOD:01000 ! monobrominated tyrosine
 
 [Term]
 id: MOD:00997
@@ -20445,12 +20475,6 @@ def: "A protein modification that effectively substitutes two hydrogen atoms of 
 synonym: "Br2Tyr" EXACT PSI-MOD-label []
 synonym: "Dibromo" RELATED PSI-MS-label []
 synonym: "Dibromo" RELATED Unimod-description []
-xref: DiffAvg: "157.79"
-xref: DiffFormula: "Br 2 C 0 H -2 N 0 O 0"
-xref: DiffMono: "155.821024"
-xref: Formula: "Br 2 C 9 H 7 N 1 O 2"
-xref: MassAvg: "320.97"
-xref: MassMono: "318.884353"
 xref: Origin: "Y"
 xref: Source: "none"
 xref: TermSpec: "none"
@@ -20554,8 +20578,8 @@ xref: MassMono: "301.987857"
 xref: Origin: "MOD:00034"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00460 ! L-cysteic acid (L-cysteine sulfonic acid)
 relationship: derives_from MOD:00034 ! L-cystine (cross-link)
+is_a: MOD:00675 ! oxidized residue
 
 [Term]
 id: MOD:01013
@@ -20798,6 +20822,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 is_a: MOD:00850 ! unnatural residue
+is_a: MOD:00306 ! residues isobaric at 113.084064 Da
 
 [Term]
 id: MOD:01027
@@ -21308,7 +21333,8 @@ xref: MassMono: "318.884353"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01023 ! 3',5'-dibromo-L-tyrosine
+relationship: derives_from MOD:01023 ! 3',5'-dibromo-L-tyrosine
+is_a: MOD:01006 ! dibrominated tyrosine
 
 [Term]
 id: MOD:01057
@@ -21324,7 +21350,8 @@ xref: MassMono: "320.882306"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01023 ! 3',5'-dibromo-L-tyrosine
+relationship: derives_from MOD:01023 ! 3',5'-dibromo-L-tyrosine
+is_a: MOD:01006 ! dibrominated tyrosine
 
 [Term]
 id: MOD:01058
@@ -21357,7 +21384,8 @@ xref: MassMono: "322.880260"
 xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:01023 ! 3',5'-dibromo-L-tyrosine
+relationship: derives_from MOD:01023 ! 3',5'-dibromo-L-tyrosine
+is_a: MOD:01006 ! dibrominated tyrosine
 
 [Term]
 id: MOD:01060
@@ -21703,7 +21731,7 @@ is_a: MOD:00905 ! modified L-cysteine residue
 [Term]
 id: MOD:01080
 name: acrylamidyl cysteinyl
-def: "modification from DeltaMass" [DeltaMass:219]
+def: "OBSOLETE because this is identical to MOD:00417.  modification from DeltaMass" [DeltaMass:219]
 comment: From DeltaMass: (name misspelled "Acrylamidyl Cystenyl") Average Mass: 174 Formula: C6H10O2N2S1 Monoisotopic Mass Change: 174.046 Average Mass Change: 174.221
 synonym: "Acrylamidyl Cystenyl" EXACT DeltaMass-label []
 xref: DiffAvg: "none"
@@ -21714,8 +21742,8 @@ xref: MassAvg: "174.22"
 xref: MassMono: "174.046299"
 xref: Origin: "C"
 xref: Source: "artifact"
-xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+xref: Remap: "MOD:00417"
+is_obsolete: true
 
 [Term]
 id: MOD:01081
@@ -21736,7 +21764,7 @@ is_a: MOD:00947 ! DeltaMass
 [Term]
 id: MOD:01082
 name: 4-glycosyloxy- (hexosyl, C6) (of proline)
-def: "modification from DeltaMass" [DeltaMass:0]
+def: "OBSOLETE because redundant with MOD:00757, remap. modification from DeltaMass" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 177. Caution: Formula does not match mass. The natural glycosylating sugar of hydroxyproline is galactose.
 xref: DiffAvg: "178.14"
 xref: DiffFormula: "C 6 H 10 O 6"
@@ -21747,7 +21775,8 @@ xref: MassMono: "259.105587"
 xref: Origin: "P"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+xref: Remap: "MOD:00757"
+is_obsolete: true
 
 [Term]
 id: MOD:01083
@@ -21787,19 +21816,20 @@ is_a: MOD:00399 ! iodoacetic acid derivatized residue
 
 [Term]
 id: MOD:01085
-name: alpha-N-gluconoylation (His Tagged proteins)
-def: "modification from DeltaMass" [DeltaMass:226]
-comment: From DeltaMass: Average Mass: 178 Formula: C6H10O6 Monoisotopic Mass Change: 178.05 Average Mass Change: 178.14 References: Geoghegan, K. F., H. B. Dixon, et al. (1999). Spontaneous alpha-N-6-phosphogluconoylation of a His tag in Escherichia coli: the cause of extra mass of 258 or 178 Da in fusion proteins. Anal Biochem 267(1): 169-84.
-xref: DiffAvg: "none"
-xref: DiffFormula: "none"
-xref: DiffMono: "none"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
-xref: Origin: "none"
-xref: Source: "none"
-xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+name: alpha-N-gluconoylated L-histidine
+def: "A protein modification that effectively replaces the N-terminal hydrogen atom of a N-terminal histidine residue with a gluconoyl group linked through a glycosidic bond. modification from DeltaMass" [PubMed:9918669, DeltaMass:226]
+comment: Occurs on His-tagged proteins expresssed in E. coli. From DeltaMass: Average Mass: 178 Formula: C6H10O6 Monoisotopic Mass Change: 178.05 Average Mass Change: 178.14 References: Geoghegan, K. F., H. B. Dixon, et al. (1999). Spontaneous alpha-N-6-phosphogluconoylation of a His tag in Escherichia coli: the cause of extra mass of 258 or 178 Da in fusion proteins. Anal Biochem 267(1): 169-84. Mass listed here is 179 because it's N-terminal.
+xref: DiffAvg: "179.15"
+xref: DiffFormula: "C 6 H 11 O 6"
+xref: DiffMono: "179.055563"
+xref: Formula: "C 12 H 18 N 3 O 7"
+xref: MassAvg: "316.29"
+xref: MassMono: "316.114475"
+xref: Origin: "H"
+xref: Source: "natural"
+xref: TermSpec: "N-term"
+is_a: MOD:00909 ! modified L-histidine residue
+is_a: MOD:00006 ! N-glycosylated residue
 
 [Term]
 id: MOD:01086
@@ -22039,7 +22069,6 @@ xref: Origin: "D"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
 is_a: MOD:00904 ! modified L-aspartic acid residue
-is_a: MOD:01029 ! succinylated residue
 
 [Term]
 id: MOD:01100
@@ -22355,19 +22384,20 @@ is_a: MOD:00947 ! DeltaMass
 
 [Term]
 id: MOD:01118
-name: alpha-N-6-phosphogluconoylation (His Tagged proteins)
-def: "modification from DeltaMass" [DeltaMass:275]
-comment: From DeltaMass: Average Mass: 258 Formula: C6H10O6HPO3 Monoisotopic Mass Change: 258.01 Average Mass Change: 258.12 References: Geoghegan, K. F., H. B. Dixon, et al. (1999). Spontaneous alpha-N-6-phosphogluconoylation of a His tag in Escherichia coli: the cause of extra mass of 258 or 178 Da in fusion proteins. Anal Biochem 267(1): 169-84.
-xref: DiffAvg: "none"
-xref: DiffFormula: "none"
-xref: DiffMono: "none"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
-xref: Origin: "none"
-xref: Source: "none"
-xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+name: alpha-N-6-phosphogluconoylated L-histidine
+def: "A protein modification that effectively replaces the N-terminal hydrogen atom of a N-terminal histidine residue with a 6-phosphogluconoyl group linked through a glycosidic bond. modification from DeltaMass" [PubMed:9918669, DeltaMass:275]
+comment: Occurs on His-tagged proteins expresssed in E. coli.From DeltaMass: Average Mass: 258 Formula: C6H10O6HPO3 Monoisotopic Mass Change: 258.01 Average Mass Change: 258.12 References: Geoghegan, K. F., H. B. Dixon, et al. (1999). Spontaneous alpha-N-6-phosphogluconoylation of a His tag in Escherichia coli: the cause of extra mass of 258 or 178 Da in fusion proteins. Anal Biochem 267(1): 169-84. Mass is one Da higher because this is an N-terminal modification
+xref: DiffAvg: "259.12"
+xref: DiffFormula: "C 6 H 12 O 9 P 1"
+xref: DiffMono: "259.021894"
+xref: Formula: "C 12 H 19 N 3 O 10 P 1"
+xref: MassAvg: "396.27"
+xref: MassMono: "396.080806"
+xref: Origin: "H"
+xref: Source: "natural"
+xref: TermSpec: "N-term"
+is_a: MOD:00909 ! modified L-histidine residue
+is_a: MOD:00006 ! N-glycosylated residue
 
 [Term]
 id: MOD:01119
@@ -22432,7 +22462,7 @@ is_a: MOD:00947 ! DeltaMass
 [Term]
 id: MOD:01122
 name: 5'phos dCytidinyl
-def: "modification from DeltaMass" [DeltaMass:0]
+def: "OBSOLETE because this is a modification that occurs to DNA/RNA and not proteins. modification from DeltaMass" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 289 with no citation.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22443,7 +22473,7 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01123
@@ -22481,7 +22511,7 @@ is_a: MOD:00947 ! DeltaMass
 [Term]
 id: MOD:01125
 name: 5'phos dThymidinyl
-def: "modification from DeltaMass" [DeltaMass:0]
+def: "OBSOLETE because this is a modification that occurs to DNA/RNA and not proteins. modification from DeltaMass" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 304 with no citation.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22492,12 +22522,12 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01126
 name: 5'phos Cytidinyl
-def: "modification from DeltaMass" [DeltaMass:0]
+def: "OBSOLETE because this is a modification that occurs to DNA/RNA and not proteins. modification from DeltaMass" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 305 with no citation.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22508,7 +22538,7 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01127
@@ -22547,7 +22577,7 @@ is_a: MOD:00947 ! DeltaMass
 [Term]
 id: MOD:01129
 name: 5'phos dAdenosyl
-def: "modification from DeltaMass" [DeltaMass:295]
+def: "OBSOLETE because this is a modification that occurs to DNA/RNA and not proteins. modification from DeltaMass" [DeltaMass:295]
 comment: From DeltaMass: Average Mass: 313 Formula: C10H12O5N5P1 Monoisotopic Mass Change: 313.058 Average Mass Change: 313.211
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22558,7 +22588,7 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01130
@@ -22579,7 +22609,7 @@ is_a: MOD:00947 ! DeltaMass
 [Term]
 id: MOD:01131
 name: 5'phos dGuanosyl
-def: "modification from DeltaMass" [DeltaMass:0]
+def: "OBSOLETE because this is a modification that occurs to DNA/RNA and not proteins. modification from DeltaMass" [DeltaMass:0]
 comment: From DeltaMass: Average Mass: 329
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22590,7 +22620,7 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "none"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01132
@@ -22662,7 +22692,7 @@ is_a: MOD:00947 ! DeltaMass
 [Term]
 id: MOD:01136
 name: dioctyl phthalate
-def: "modification from DeltaMass" [DeltaMass:309]
+def: "OBSOLETE because this is a small molecule contaminant and not a modification to a polypeptide. modification from DeltaMass" [DeltaMass:309]
 comment: From DeltaMass: Average Mass: 391 Average Mass Change: 391 Notes: A common plasticizer, and, unfortunaltely, a common contaminate. A sodium adduct is often associated with this peak at 413.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22673,7 +22703,7 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01137
@@ -22697,7 +22727,7 @@ is_a: MOD:01120 ! 2,2,5,7,8-pentamethylchroman-6-sulfonyl chloride derivatized r
 [Term]
 id: MOD:01138
 name: Aedans Cystenyl
-def: "modification from DeltaMass" [DeltaMass:311]
+def: "OBSOLETE because no evidence has been seen for this protein modification. modification from DeltaMass" [DeltaMass:311]
 comment: [probably aminoethyldansyl, JSG] From DeltaMass: (name misspelled "Aedans Cystenyl", and formula incorrect, N and O reversed) Average Mass: 409 Abbreviation: Aedans-Cys Formula: C17H19O3N5S2 Monoisotopic Mass Change: 409.077 Average Mass Change: 409.482
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22708,12 +22738,12 @@ xref: MassMono: "none"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01139
 name: dioctyl phthalate sodium adduct
-def: "modification from DeltaMass" [DeltaMass:312]
+def: "OBSOLETE because this is a MS contaminant, not a known modification to a polypeptide. modification from DeltaMass" [DeltaMass:312]
 comment: From DeltaMass: Mass: Average Mass Change: 413 Notes: A common plasticizer, and, unfortunaltely, a common contaminate. A sodium adduct is often associated with this peak at 413.
 xref: DiffAvg: "none"
 xref: DiffFormula: "none"
@@ -22724,7 +22754,7 @@ xref: MassMono: "none"
 xref: Origin: "none"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+is_obsolete: true
 
 [Term]
 id: MOD:01140
@@ -22856,7 +22886,7 @@ xref: Origin: "H"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0672"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:02087 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00909 ! modified L-histidine residue
 relationship: derives_from MOD:00049 ! 2'-[3-carboxamido-3-(trimethylammonio)propyl]-L-histidine
 
@@ -22882,19 +22912,22 @@ is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
 id: MOD:01147
-name: (Hex)3-HexNAc-(dHex)HexNAc
-def: "modification from DeltaMass" [DeltaMass:0]
+name: dHex1Hex3HexNAc2 N4-glycosylated asparagine
+def: "modification from DeltaMass" [DeltaMass:0, Unimod:1761]
 comment: From DeltaMass: Average Mass: 1,039
-xref: DiffAvg: "none"
-xref: DiffFormula: "none"
-xref: DiffMono: "none"
-xref: Formula: "none"
-xref: MassAvg: "none"
-xref: MassMono: "none"
-xref: Origin: "none"
-xref: Source: "none"
+xref: DiffAvg: "1038.95"
+xref: DiffFormula: "C 40 H 66 N 2 O 29"
+xref: DiffMono: "1038.375124"
+xref: Formula: "C 44 H 72 N 4 O 31"
+xref: MassAvg: "1153.06"
+xref: MassMono: "1152.418052"
+xref: Origin: "N"
+xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00947 ! DeltaMass
+xref: Unimod: "Unimod:1761"
+xref: GNOme: "GNO:G20956ZV"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00160 ! N4-glycosyl-L-asparagine
 
 [Term]
 id: MOD:01148
@@ -23130,7 +23163,7 @@ is_a: MOD:00701 ! nucleotide or nucleic acid modified residue
 
 [Term]
 id: MOD:01164
-name: riboflavin-phosphoryl
+name: riboflavin-phosphorylated residue
 def: "A protein modification that effectively results from forming an adduct with a compound containing a riboflavin phosphate (flavin mononucleotide, FMN) group through a phosphodiester bond." [Unimod:442]
 subset: PSI-MOD-slim
 synonym: "FMN" RELATED PSI-MS-label []
@@ -23145,7 +23178,7 @@ xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:442"
-is_a: MOD:00896 ! FMN modified residue
+is_a: MOD:00697 ! flavin modified residue
 
 [Term]
 id: MOD:01165
@@ -23299,8 +23332,8 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:1"
 xref: UniProt: "PTM-0233"
-is_a: MOD:00644 ! O-acetylated residue
-is_a: MOD:01186 ! acetylated L-threonine
+is_a: MOD:00644 ! mono O-acetylated residue
+is_a: MOD:01186 ! monoacetylated L-threonine
 
 [Term]
 id: MOD:01172
@@ -23558,7 +23591,6 @@ xref: Origin: "C, H"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0681"
-is_a: MOD:00895 ! FAD modified residue
 is_a: MOD:02044 ! crosslinked L-cysteine residue
 is_a: MOD:02048 ! crosslinked L-histidine residue
 is_a: MOD:01621 ! flavin crosslinked residues
@@ -23621,7 +23653,6 @@ xref: MassMono: "299.891620"
 xref: Origin: "C, C"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
-is_a: MOD:00007 ! selenium substitution for sulfur
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -23652,13 +23683,12 @@ xref: MassMono: "114.042927"
 xref: Origin: "D"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00012 ! L-asparagine residue
 is_a: MOD:00674 ! amidated residue
 is_a: MOD:00904 ! modified L-aspartic acid residue
 
 [Term]
 id: MOD:01186
-name: acetylated L-threonine
+name: monoacetylated L-threonine
 def: "A protein modification that effectively converts an L-threonine residue to either N-acetyl-L-threonne, or O-acetyl-Lthreonine." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "AcThr" EXACT PSI-MOD-label []
@@ -23670,7 +23700,7 @@ xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "T"
 xref: Source: "natural"
-is_a: MOD:00394 ! acetylated residue
+is_a: MOD:00394 ! monoacetylated residue
 is_a: MOD:00917 ! modified L-threonine residue
 
 [Term]
@@ -23792,7 +23822,7 @@ is_a: MOD:00561 ! N-ethyl iodoacetamide-d0
 
 [Term]
 id: MOD:01193
-name: phosphorylation to pyridyl thiol - site T
+name: pyridyl thiol modified L-threonine
 def: "modification from Unimod Chemical derivative -" [PubMed:1093385, Unimod:264#T]
 synonym: "PET" RELATED PSI-MS-label []
 synonym: "phosphorylation to pyridyl thiol" RELATED Unimod-description []
@@ -23806,11 +23836,12 @@ xref: Origin: "T"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:264"
-is_a: MOD:00586 ! phosphorylation to pyridyl thiol
+is_a: MOD:00917 ! modified L-threonine residue
+is_a: MOD:00586 ! pyridyl thiol modified residue
 
 [Term]
 id: MOD:01194
-name: phosphorylation to pyridyl thiol - site S
+name: pyridyl thiol modified L-serine
 def: "modification from Unimod Chemical derivative -" [PubMed:15279557, Unimod:264#S]
 synonym: "PET" RELATED PSI-MS-label []
 synonym: "phosphorylation to pyridyl thiol" RELATED Unimod-description []
@@ -23824,7 +23855,8 @@ xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:264"
-is_a: MOD:00586 ! phosphorylation to pyridyl thiol
+is_a: MOD:00916 ! modified L-serine residue
+is_a: MOD:00586 ! pyridyl thiol modified residue
 
 [Term]
 id: MOD:01195
@@ -24051,7 +24083,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:160"
 is_a: MOD:00528 ! Hex1HexNAc1NeuAc2 glycosylated residue
-is_a: MOD:00917 ! modified L-threonine residue
+is_a: MOD:00005 ! O-glycosyl-L-threonine
 
 [Term]
 id: MOD:01207
@@ -24551,7 +24583,8 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:59"
-is_a: MOD:01398 ! N6-propanoyl-L-lysine
+relationship: derives_from MOD:01398 ! N6-propanoyl-L-lysine
+is_a: MOD:01428 ! (13)C isotope tagged reagent
 
 [Term]
 id: MOD:01232
@@ -24570,7 +24603,8 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:58"
-is_a: MOD:01398 ! N6-propanoyl-L-lysine
+relationship: derives_from MOD:01398 ! N6-propanoyl-L-lysine
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:01233
@@ -24589,7 +24623,7 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:56"
-is_a: MOD:00064 ! N6-acetyl-L-lysine
+relationship: derives_from MOD:00064 ! N6-acetyl-L-lysine
 is_a: MOD:00449 ! acetate labeling reagent (N-term) (heavy form, +3amu)
 
 [Term]
@@ -25065,7 +25099,7 @@ is_a: MOD:00547 ! 6-aminoquinolyl-N-hydroxysuccinimidyl carbamate
 
 [Term]
 id: MOD:01258
-name: N-methylmaleimide - site C
+name: N-methylmaleimide modified L-cysteine
 def: "modification from Unimod Chemical derivative -" [PubMed:9448752, Unimod:314#C]
 synonym: "Nmethylmaleimide" RELATED PSI-MS-label []
 synonym: "Nmethylmaleimide" RELATED Unimod-description []
@@ -25084,7 +25118,7 @@ is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
 id: MOD:01259
-name: N-methylmaleimide - site K
+name: N-methylmaleimide modified L-lysine
 def: "modification from Unimod Chemical derivative -" [PubMed:9448752, Unimod:314#K]
 synonym: "Nmethylmaleimide" RELATED PSI-MS-label []
 synonym: "Nmethylmaleimide" RELATED Unimod-description []
@@ -25104,7 +25138,7 @@ is_a: MOD:00912 ! modified L-lysine residue
 [Term]
 id: MOD:01260
 name: nucleophilic addtion to cytopiloyne - site Y
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#Y]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#Y]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -25117,13 +25151,12 @@ xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00590 ! nucleophilic addtion to cytopiloyne
-is_a: MOD:00919 ! modified L-tyrosine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01261
 name: nucleophilic addtion to cytopiloyne - site S
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#C]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#C]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -25136,13 +25169,12 @@ xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00590 ! nucleophilic addtion to cytopiloyne
-is_a: MOD:00916 ! modified L-serine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01262
 name: nucleophilic addition to cytopiloyne - site R
-def: "modification from Unimod Chemical derivative -" [PubMed:12590383, PubMed:15549660, Unimod:270#R]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:12590383, PubMed:15549660, Unimod:270#R]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -25155,13 +25187,12 @@ xref: Origin: "R"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00590 ! nucleophilic addtion to cytopiloyne
-is_a: MOD:00902 ! modified L-arginine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01263
 name: nucleophilic addtion to cytopiloyne - site K
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#K]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#K]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -25174,13 +25205,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00590 ! nucleophilic addtion to cytopiloyne
-is_a: MOD:00912 ! modified L-lysine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01264
 name: nucleophilic addtion to cytopiloyne - site C
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#C]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#C]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -25193,13 +25223,12 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00590 ! nucleophilic addtion to cytopiloyne
-is_a: MOD:00905 ! modified L-cysteine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01265
 name: nucleophilic addtion to cytopiloyne - site P
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#P]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:270#P]
 synonym: "Cytopiloyne" RELATED PSI-MS-label []
 synonym: "nucleophilic addtion to cytopiloyne" RELATED Unimod-description []
 xref: DiffAvg: "362.38"
@@ -25212,13 +25241,12 @@ xref: Origin: "P"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:270"
-is_a: MOD:00590 ! nucleophilic addtion to cytopiloyne
-is_a: MOD:00915 ! modified L-proline residue
+is_obsolete: true
 
 [Term]
 id: MOD:01266
 name: nucleophilic addition to cytopiloyne+H2O - site C
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#C]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#C]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -25231,13 +25259,12 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00591 ! nucleophilic addition to cytopiloyne+H2O
-is_a: MOD:00905 ! modified L-cysteine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01267
 name: nucleophilic addition to cytopiloyne+H2O - site K
-def: "modification from Unimod Chemical derivative -" [PubMed:11746907, PubMed:15549660, Unimod:271#K]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:11746907, PubMed:15549660, Unimod:271#K]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -25250,13 +25277,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00591 ! nucleophilic addition to cytopiloyne+H2O
-is_a: MOD:00912 ! modified L-lysine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01268
 name: nucleophilic addition to cytopiloyne+H2O - site T
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#T]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#T]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -25269,13 +25295,12 @@ xref: Origin: "T"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00591 ! nucleophilic addition to cytopiloyne+H2O
-is_a: MOD:00917 ! modified L-threonine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01269
 name: nucleophilic addition to cytopiloyne+H2O - site R
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#R]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#R]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -25288,13 +25313,12 @@ xref: Origin: "R"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00591 ! nucleophilic addition to cytopiloyne+H2O
-is_a: MOD:00902 ! modified L-arginine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01270
 name: nucleophilic addition to cytopiloyne+H2O - site S
-def: "modification from Unimod Chemical derivative -" [PubMed:14670044, PubMed:15549660, Unimod:271#S]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:14670044, PubMed:15549660, Unimod:271#S]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -25307,13 +25331,12 @@ xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00591 ! nucleophilic addition to cytopiloyne+H2O
-is_a: MOD:00916 ! modified L-serine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01271
 name: nucleophilic addition to cytopiloyne+H2O - site Y
-def: "modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#Y]
+def: "OBSOLETE because there is no evidence in the literature of covalent modification of polypeptides with cytopiloyne or cytopiloyne+H2O.  Modifications could potentially happen, but are not experimentally verified. [PMT] modification from Unimod Chemical derivative -" [PubMed:15549660, Unimod:271#Y]
 synonym: "Cytopiloyne+water" RELATED PSI-MS-label []
 synonym: "nucleophilic addition to cytopiloyne+H2O" RELATED Unimod-description []
 xref: DiffAvg: "380.39"
@@ -25326,8 +25349,7 @@ xref: Origin: "Y"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:271"
-is_a: MOD:00591 ! nucleophilic addition to cytopiloyne+H2O
-is_a: MOD:00919 ! modified L-tyrosine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01272
@@ -25426,7 +25448,7 @@ is_a: MOD:00919 ! modified L-tyrosine residue
 
 [Term]
 id: MOD:01277
-name: crotonaldehyde - site C
+name: crotonylated L-cysteine
 def: "modification from Unimod Other -" [PubMed:11283024, Unimod:253#C]
 synonym: "Crotonaldehyde" RELATED PSI-MS-label []
 synonym: "Crotonaldehyde" RELATED Unimod-description []
@@ -25440,12 +25462,12 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:253"
-is_a: MOD:00576 ! crotonaldehyde
+is_a: MOD:00576 ! crotonylated residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
 id: MOD:01278
-name: crotonaldehyde - site K
+name: crotonylated L-lysine
 def: "modification from Unimod Other -" [PubMed:11283024, Unimod:253#K]
 synonym: "Crotonaldehyde" RELATED PSI-MS-label []
 synonym: "Crotonaldehyde" RELATED Unimod-description []
@@ -25459,12 +25481,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:253"
-is_a: MOD:00576 ! crotonaldehyde
+is_a: MOD:00576 ! crotonylated residue
 is_a: MOD:00912 ! modified L-lysine residue
 
 [Term]
 id: MOD:01279
-name: crotonaldehyde - site H
+name: crotonylated L-histidine
 def: "modification from Unimod Other -" [PubMed:11283024, PubMed:1443554, Unimod:253#H]
 synonym: "Crotonaldehyde" RELATED PSI-MS-label []
 synonym: "Crotonaldehyde" RELATED Unimod-description []
@@ -25478,7 +25500,7 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:253"
-is_a: MOD:00576 ! crotonaldehyde
+is_a: MOD:00576 ! crotonylated residue
 is_a: MOD:00909 ! modified L-histidine residue
 
 [Term]
@@ -25522,7 +25544,7 @@ is_a: MOD:00916 ! modified L-serine residue
 [Term]
 id: MOD:01282
 name: acrolein addition +56 - site H
-def: "modification from Unimod Other -" [PubMed:10825247, PubMed:15541752, Unimod:206#H]
+def: "OBSOLETE because this modification is not supported by the linked literature [PMT]" [PubMed:10825247, PubMed:15541752, Unimod:206#H]
 synonym: "Acrolein addition +56" RELATED Unimod-description []
 synonym: "Delta:H(4)C(3)O(1)" RELATED PSI-MS-label []
 xref: DiffAvg: "56.06"
@@ -25535,13 +25557,12 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:206"
-is_a: MOD:00557 ! acrolein addition +56
-is_a: MOD:00909 ! modified L-histidine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01283
 name: acrolein addition +56 - site K
-def: "modification from Unimod Other -" [PubMed:10825247, PubMed:15541752, Unimod:206#K]
+def: "OBSOLETE because this modification is not supported by the linked literature [PMT]" [PubMed:10825247, PubMed:15541752, Unimod:206#K]
 synonym: "Acrolein addition +56" RELATED Unimod-description []
 synonym: "Delta:H(4)C(3)O(1)" RELATED PSI-MS-label []
 xref: DiffAvg: "56.06"
@@ -25554,13 +25575,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:206"
-is_a: MOD:00557 ! acrolein addition +56
-is_a: MOD:00912 ! modified L-lysine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01284
 name: acrolein addition +56 - site C
-def: "modification from Unimod Other -" [PubMed:10825247, PubMed:15541752, PubMed:9254591, Unimod:206#C]
+def: "OBSOLETE because this modification is not supported by the linked literature [PMT]" [PubMed:10825247, PubMed:15541752, PubMed:9254591, Unimod:206#C]
 synonym: "Acrolein addition +56" RELATED Unimod-description []
 synonym: "Delta:H(4)C(3)O(1)" RELATED PSI-MS-label []
 xref: DiffAvg: "56.06"
@@ -25573,8 +25593,7 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:206"
-is_a: MOD:00557 ! acrolein addition +56
-is_a: MOD:00905 ! modified L-cysteine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01285
@@ -25636,7 +25655,7 @@ is_a: MOD:00912 ! modified L-lysine residue
 [Term]
 id: MOD:01288
 name: acetaldehyde +28 - site H
-def: "modification from Unimod Other -" [Unimod:255#H]
+def: "OBSOLETE because this is not supported by the literature [PMT]" [Unimod:255#H]
 synonym: "Acetaldehyde +28" RELATED Unimod-description []
 synonym: "Delta:H(4)C(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "28.05"
@@ -25649,13 +25668,12 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:255"
-is_a: MOD:00578 ! acetaldehyde +28
-is_a: MOD:00909 ! modified L-histidine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01289
 name: acetaldehyde +28 - site K
-def: "modification from Unimod Other -" [Unimod:255#K]
+def: "OBSOLETE because this is not supported by the literature [PMT]" [Unimod:255#K]
 synonym: "Acetaldehyde +28" RELATED Unimod-description []
 synonym: "Delta:H(4)C(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "28.05"
@@ -25668,8 +25686,7 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:255"
-is_a: MOD:00578 ! acetaldehyde +28
-is_a: MOD:00912 ! modified L-lysine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01290
@@ -26162,8 +26179,9 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:64"
+relationship: derives_from MOD:01819 ! N6-succinyl-L-lysine
+is_a: MOD:00670 ! N-acylated residue
 is_a: MOD:01426 ! isotope tagged reagent derivatized residue
-is_a: MOD:01819 ! N6-succinyl-L-lysine
 
 [Term]
 id: MOD:01315
@@ -26181,7 +26199,9 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:65"
-is_a: MOD:01819 ! N6-succinyl-L-lysine
+relationship: derives_from MOD:01819 ! N6-succinyl-L-lysine
+is_a: MOD:00670 ! N-acylated residue
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:01316
@@ -26199,7 +26219,9 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:66"
-is_a: MOD:01819 ! N6-succinyl-L-lysine
+relationship: derives_from MOD:01819 ! N6-succinyl-L-lysine
+is_a: MOD:00670 ! N-acylated residue
+is_a: MOD:01428 ! (13)C isotope tagged reagent
 
 [Term]
 id: MOD:01317
@@ -26302,7 +26324,7 @@ is_a: MOD:00905 ! modified L-cysteine residue
 [Term]
 id: MOD:01322
 name: propionaldehyde +40 - site K
-def: "modification from Unimod Other -" [PubMed:15549660, Unimod:256#K]
+def: "OBSOLETE because not supported by the linked literature [PMT]. modification from Unimod Other -" [PubMed:15549660, Unimod:256#K]
 synonym: "Delta:H(4)C(3)" RELATED PSI-MS-label []
 synonym: "Propionaldehyde +40" RELATED Unimod-description []
 xref: DiffAvg: "40.06"
@@ -26315,13 +26337,12 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:256"
-is_a: MOD:00579 ! propionaldehyde +40
-is_a: MOD:00912 ! modified L-lysine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01323
 name: propionaldehyde +40 - site H
-def: "modification from Unimod Other -" [Unimod:256#H]
+def: "OBSOLETE because not supported by the linked literature [PMT]. modification from Unimod Other -" [Unimod:256#H]
 synonym: "Delta:H(4)C(3)" RELATED PSI-MS-label []
 synonym: "Propionaldehyde +40" RELATED Unimod-description []
 xref: DiffAvg: "40.06"
@@ -26334,13 +26355,12 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:256"
-is_a: MOD:00579 ! propionaldehyde +40
-is_a: MOD:00909 ! modified L-histidine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01324
 name: acetaldehyde +26 - site H
-def: "modification from Unimod Other -" [PubMed:7744761, Unimod:254#H]
+def: "OBSOLETE because this is not supported by the linked literature [PMT]" [PubMed:7744761, Unimod:254#H]
 synonym: "Acetaldehyde +26" RELATED Unimod-description []
 synonym: "Delta:H(2)C(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "26.04"
@@ -26353,13 +26373,12 @@ xref: Origin: "H"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:254"
-is_a: MOD:00577 ! acetaldehyde +26
-is_a: MOD:00909 ! modified L-histidine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01325
 name: acetaldehyde +26 - site K
-def: "modification from Unimod Other -" [PubMed:7744761, Unimod:254#K]
+def: "OBSOLETE because this is not supported by the linked literature [PMT]" [PubMed:7744761, Unimod:254#K]
 synonym: "Acetaldehyde +26" RELATED Unimod-description []
 synonym: "Delta:H(2)C(2)" RELATED PSI-MS-label []
 xref: DiffAvg: "26.04"
@@ -26372,8 +26391,7 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:254"
-is_a: MOD:00577 ! acetaldehyde +26
-is_a: MOD:00912 ! modified L-lysine residue
+is_obsolete: true
 
 [Term]
 id: MOD:01326
@@ -26607,7 +26625,7 @@ xref: Origin: "N"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:528"
-is_a: MOD:01181 ! L-aspartic acid 4-methyl ester
+relationship: derives_from MOD:01181 ! L-aspartic acid 4-methyl ester
 is_a: MOD:01369 ! deamidated and methyl esterified residue
 
 [Term]
@@ -26882,7 +26900,7 @@ xref: Origin: "W"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:354"
-is_a: MOD:00461 ! nitrosylation
+is_a: MOD:00461 ! nitrated residue
 is_a: MOD:00918 ! modified L-tryptophan residue
 
 [Term]
@@ -26905,7 +26923,7 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:354"
 xref: UniProt: "PTM-0213"
-is_a: MOD:00461 ! nitrosylation
+is_a: MOD:00461 ! nitrated residue
 is_a: MOD:00919 ! modified L-tyrosine residue
 
 [Term]
@@ -26948,7 +26966,7 @@ is_a: MOD:00160 ! N4-glycosyl-L-asparagine
 
 [Term]
 id: MOD:01355
-name: Hex1HexNAc1NeuAc1O-glycosylated threonine
+name: Hex1HexNAc1NeuAc1 O-glycosylated threonine
 def: "A protein modification that effectively replaces an O3 hydrogen atom of a threonine residue with a carbohydrate-like group composed of Hex1HexNAc1NeuAc1 linked through a glycosidic bond." [Unimod:149#T]
 synonym: "Hex(1)HexNAc(1)NeuAc(1)" RELATED PSI-MS-label []
 synonym: "Hex1HexNAc1NeuAc1" RELATED Unimod-description []
@@ -26963,7 +26981,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:149"
 is_a: MOD:00517 ! Hex1HexNAc1NeuAc1 glycosylated residue
-is_a: MOD:00917 ! modified L-threonine residue
+is_a: MOD:00005 ! O-glycosyl-L-threonine
 
 [Term]
 id: MOD:01356
@@ -27134,7 +27152,7 @@ xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:478"
-is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide
+is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide modified residue
 is_a: MOD:00916 ! modified L-serine residue
 
 [Term]
@@ -27153,7 +27171,7 @@ xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:478"
-is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide
+is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide modified residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -27172,7 +27190,7 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:478"
-is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide
+is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide modified residue
 is_a: MOD:00912 ! modified L-lysine residue
 
 [Term]
@@ -27191,7 +27209,7 @@ xref: Origin: "P"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:478"
-is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide
+is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide modified residue
 is_a: MOD:00915 ! modified L-proline residue
 
 [Term]
@@ -27210,7 +27228,7 @@ xref: Origin: "R"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:478"
-is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide
+is_a: MOD:00626 ! fluorescein-5-thiosemicarbazide modified residue
 is_a: MOD:00902 ! modified L-arginine residue
 
 [Term]
@@ -27231,7 +27249,7 @@ xref: Source: "none"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:528"
 is_a: MOD:00393 ! O-methylated residue
-is_a: MOD:00400 ! deamidated residue
+relationship: contains MOD:00400 ! deamidated residue
 
 [Term]
 id: MOD:01370
@@ -27676,7 +27694,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0361"
 is_a: MOD:02049 ! crosslinked L-isoleucine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01390
@@ -27699,7 +27717,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0365"
 is_a: MOD:02059 ! crosslinked L-valine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01391
@@ -27722,7 +27740,6 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0373"
 is_a: MOD:02059 ! crosslinked L-valine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
 
 [Term]
 id: MOD:01392
@@ -27745,7 +27762,6 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0352"
 is_a: MOD:02042 ! crosslinked L-asparagine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
 relationship: derives_from MOD:00656 ! C-methylated residue
 
 [Term]
@@ -27858,7 +27874,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0386"
 is_a: MOD:02055 ! crosslinked L-serine residue
 is_a: MOD:01422 ! oxazole/oxazoline ring crosslinked residues (Thr)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01398
@@ -27925,7 +27941,7 @@ synonym: "poly[2'-adenosine 5'-(trihydrogen diphosphate) 5'->5'-ester with 1alph
 xref: Origin: "K"
 xref: Source: "natural"
 xref: TermSpec: "C-term"
-is_a: MOD:00752 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+is_a: MOD:02087 ! adenosine diphosphoribosyl (ADP-ribosyl) modified residue
 is_a: MOD:00912 ! modified L-lysine residue
 
 [Term]
@@ -28014,7 +28030,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0359"
 is_a: MOD:02042 ! crosslinked L-asparagine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01405
@@ -28035,7 +28051,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02054 ! crosslinked L-proline residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01406
@@ -28058,7 +28074,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0364"
 is_a: MOD:02056 ! crosslinked L-threonine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01407
@@ -28081,6 +28097,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0366"
 is_a: MOD:02053 ! crosslinked L-phenylalanine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01408
@@ -28103,6 +28120,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0392"
 is_a: MOD:02056 ! crosslinked L-threonine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01409
@@ -28398,6 +28416,7 @@ name: (13)C isotope tagged reagent
 def: "A protein modification that forms an adduct with a (13)C labeled compound used as a reagent." [PubMed:18688235]
 subset: PSI-MOD-slim
 is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:00842 ! (13)C labeled residue
 
 [Term]
 id: MOD:01429
@@ -28405,6 +28424,7 @@ name: (15)N isotope tagged reagent
 def: "A protein modification that forms an adduct with a (15)N labeled compound used as a reagent." [PubMed:18688235]
 subset: PSI-MOD-slim
 is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:00843 ! (15)N labeled residue
 
 [Term]
 id: MOD:01430
@@ -28412,6 +28432,7 @@ name: (18)O isotope tagged reagent
 def: "A protein modification that forms an adduct with a (13)C labeled compound used as a reagent." [PubMed:18688235]
 subset: PSI-MOD-slim
 is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:00844 ! (18)O labeled residue
 
 [Term]
 id: MOD:01431
@@ -28419,6 +28440,7 @@ name: (2)H deuterium tagged reagent
 def: "A protein modification that forms an adduct with a (2)H labeled compound used as a reagent." [PubMed:18688235]
 subset: PSI-MOD-slim
 is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+is_a: MOD:00839 ! (2)H deuterium labeled residue
 
 [Term]
 id: MOD:01432
@@ -28462,7 +28484,6 @@ xref: TermSpec: "C-term"
 xref: UniProt: "PTM-0379"
 is_a: MOD:00683 ! dehydrogenated residue
 is_a: MOD:00917 ! modified L-threonine residue
-is_a: MOD:00960 ! decarboxylated residue
 
 [Term]
 id: MOD:01434
@@ -28549,6 +28570,7 @@ xref: UniProt: "PTM-0380"
 is_a: MOD:02054 ! crosslinked L-proline residue
 is_a: MOD:02055 ! crosslinked L-serine residue
 is_a: MOD:01629 ! cyclo[(prolylserin)-O-yl] cysteinate
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01438
@@ -28608,6 +28630,7 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 is_a: MOD:00859 ! modified residue that can arise from different natural residues
+is_a: MOD:00594 ! residues isobaric at 113.047678 Da
 
 [Term]
 id: MOD:01441
@@ -28656,7 +28679,7 @@ xref: MassMono: "1140.326447"
 xref: Origin: "E, E, E, E, H, H"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00438 ! myristoylated residue
+relationship: contains MOD:00438 ! myristoylated residue
 is_a: MOD:00738 ! iron containing modified residue
 is_a: MOD:00740 ! manganese containing modified residue
 is_a: MOD:02068 ! metal or metal cluster coordinated L-glutamic acid residue
@@ -28810,7 +28833,7 @@ xref: MassMono: "166.998359"
 xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00046 ! O-phospho-L-serine
+is_a: MOD:00916 ! modified L-serine
 is_a: MOD:00431 ! modified residue with a secondary neutral loss
 relationship: derives_from MOD:00159 ! O-phosphopantetheine-L-serine
 
@@ -28829,7 +28852,7 @@ xref: MassMono: "166.998359"
 xref: Origin: "MOD:00159"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00046 ! O-phospho-L-serine
+is_a: MOD:00916 ! modified L-serine
 is_a: MOD:00431 ! modified residue with a secondary neutral loss
 relationship: derives_from MOD:00159 ! O-phosphopantetheine-L-serine
 
@@ -28926,9 +28949,9 @@ xref: MassMono: "103.009185"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00014 ! L-cysteine residue
 is_a: MOD:00749 ! sulfur substitution for oxygen
 is_a: MOD:00916 ! modified L-serine residue
+is_a: MOD:02088 ! natural, standard, encoded residue substitution
 
 [Term]
 id: MOD:01458
@@ -28947,7 +28970,7 @@ xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:1"
-is_a: MOD:00408 ! N-acetylated residue
+is_a: MOD:00408 ! mono N-acetylated residue
 is_a: MOD:01696 ! alpha-amino acylated residue
 
 [Term]
@@ -29228,7 +29251,7 @@ xref: MassMono: "485.123302"
 xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00399 ! iodoacetic acid derivatized residue
+relationship: derives_from MOD:00399 ! iodoacetic acid derivatized residue
 is_a: MOD:00861 ! phosphorus containing modified residue
 is_a: MOD:00916 ! modified L-serine residue
 relationship: derives_from MOD:00159 ! O-phosphopantetheine-L-serine
@@ -29247,7 +29270,7 @@ xref: MassMono: "484.139286"
 xref: Origin: "S"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00397 ! iodoacetamide derivatized residue
+relationship: derives_from MOD:00397 ! iodoacetamide derivatized residue
 is_a: MOD:00861 ! phosphorus containing modified residue
 is_a: MOD:00916 ! modified L-serine residue
 relationship: derives_from MOD:00159 ! O-phosphopantetheine-L-serine
@@ -31902,7 +31925,6 @@ xref: Origin: "E"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0406"
-is_a: MOD:00674 ! amidated residue
 is_a: MOD:00906 ! modified L-glutamic acid residue
 
 [Term]
@@ -31920,7 +31942,6 @@ xref: MassMono: "352.067167"
 xref: Origin: "E"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
-is_a: MOD:00674 ! amidated residue
 is_a: MOD:00861 ! phosphorus containing modified residue
 is_a: MOD:00906 ! modified L-glutamic acid residue
 
@@ -31943,7 +31964,6 @@ xref: MassMono: "256.105922"
 xref: Origin: "E"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
-is_a: MOD:00674 ! amidated residue
 is_a: MOD:00906 ! modified L-glutamic acid residue
 
 [Term]
@@ -32034,7 +32054,6 @@ xref: MassMono: "692.141411"
 xref: Origin: "C, H"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00896 ! FMN modified residue
 is_a: MOD:02044 ! crosslinked L-cysteine residue
 is_a: MOD:02048 ! crosslinked L-histidine residue
 is_a: MOD:01621 ! flavin crosslinked residues
@@ -32179,7 +32198,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0596"
 is_a: MOD:00005 ! O-glycosyl-L-threonine
-is_a: MOD:00595 ! mannosylated residue
+is_a: MOD:01804 ! glycosylphosphorylated residue
 
 [Term]
 id: MOD:01618
@@ -32796,13 +32815,14 @@ is_a: MOD:01651 ! natural, standard, encoded residue removal
 [Term]
 id: MOD:01651
 name: natural, standard, encoded residue removal
-def: "A protein modification that effectively removes or replaces a natural, standard, encoded residue." [PubMed:18688235]
-comment: This represents the loss or replacement of an encoded residue in a polypeptide, and may be combined with the formula or mass of another entry that is the replacement residue to represent a mutation or substitution.
+def: "A protein modification that effectively removes a natural, standard, encoded residue." [PubMed:18688235]
+comment: This represents the loss of an encoded residue in a polypeptide.
 subset: PSI-MOD-slim
 xref: Origin: "X"
 xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:00009 ! natural residue
+is_a: MOD:01156 ! protein modification characterized by chemical process
 
 [Term]
 id: MOD:01652
@@ -33219,7 +33239,7 @@ xref: Origin: "X"
 xref: Source: "none"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:43"
-is_a: MOD:00436 ! N-acetylhexosaminylated
+is_a: MOD:00436 ! N-acetylhexosaminylated residue
 
 [Term]
 id: MOD:01674
@@ -33328,12 +33348,12 @@ xref: Origin: "P"
 xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:00915 ! modified L-proline residue
-is_a: MOD:01673 ! N-acetylaminohexosylated residue
+relationship: contains MOD:01673 ! N-acetylaminohexosylated residue
 
 [Term]
 id: MOD:01678
 name: N6-carbamoyl-L-lysine
-def: "A protein modification that effectively coverts L-lysine to N6-carbamoyl-L-lysine." [DeltaMass:56, OMSSA:31, PubMed:10978403, PubMed:12203680, Unimod:5#K]
+def: "A protein modification that effectively coverts L-lysine to N6-carbamoyl-L-lysine." [DeltaMass:56, OMSSA:31, PubMed:10978403, PubMed:12203680, Unimod:5#K, ChEBI:144369]
 comment: This modification can be produced by hydrogen cyanate, either as a reagent or as released by urea degradation in solution [JSG].
 subset: PSI-MOD-slim
 synonym: "2-amino-6-ureido-hexanoic acid" EXACT PSI-MOD-alternate []
@@ -33343,6 +33363,7 @@ synonym: "carbamylk" EXACT OMSSA-label []
 synonym: "homocitrulline" EXACT PSI-MOD-alternate []
 synonym: "N6-(aminocarbonyl)-L-lysine" EXACT PSI-MOD-alternate []
 synonym: "N6CbmLys" EXACT PSI-MOD-label []
+synonym: "MOD_RES N6-carbamoyllysine" EXACT UniProt-feature []
 xref: DiffAvg: "43.02"
 xref: DiffFormula: "C 1 H 1 N 1 O 1"
 xref: DiffMono: "43.005814"
@@ -33353,6 +33374,8 @@ xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:5"
+xref: UniProt: "PTM-0675"
+is_a: MOD:00912 ! modified L-lysine residue
 is_a: MOD:00398 ! carbamoylated residue
 
 [Term]
@@ -35443,7 +35466,7 @@ xref: Origin: "K"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0474"
-is_a: MOD:00037 ! 5-hydroxy-L-lysine
+relationship: derives_from MOD:00037 ! 5-hydroxy-L-lysine
 is_a: MOD:01875 ! N6-acylated L-lysine
 
 [Term]
@@ -35732,7 +35755,6 @@ xref: MassMono: "176.025563"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00397 ! iodoacetamide derivatized residue
 is_a: MOD:00708 ! sulfur oxygenated L-cysteine
 is_a: MOD:01854 ! sulfur monooxygenated residue
 relationship: derives_from MOD:01060 ! S-carboxamidomethyl-L-cysteine
@@ -35769,8 +35791,8 @@ xref: Origin: "M"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 is_a: MOD:00839 ! (2)H deuterium labeled residue
+is_a: MOD:00842 ! (13)C labeled residue
 is_a: MOD:00913 ! modified L-methionine residue
-is_a: MOD:01794 ! 1x(13)C,3x(2)H labeled monomethylated residue
 
 [Term]
 id: MOD:01796
@@ -35787,7 +35809,6 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 is_a: MOD:00839 ! (2)H deuterium labeled residue
 is_a: MOD:00913 ! modified L-methionine residue
-is_a: MOD:01794 ! 1x(13)C,3x(2)H labeled monomethylated residue
 
 [Term]
 id: MOD:01797
@@ -36066,7 +36087,7 @@ xref: Origin: "M"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:268"
-is_a: MOD:00719 ! L-methionine sulfoxide
+relationship: derives_from MOD:00719 ! L-methionine sulfoxide
 is_a: MOD:01809 ! 5x(13)C,1x(15)N labeled residue
 
 [Term]
@@ -36133,7 +36154,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0456"
 is_a: MOD:02045 ! crosslinked L-glutamic acid residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01816
@@ -36157,7 +36178,7 @@ is_a: MOD:01622 ! monohydroxylated tryptophan
 
 [Term]
 id: MOD:01817
-name: oxidation of tryptophan to 2'-oxo-L-tryptophan
+name: 2'-oxo-L-tryptophan
 def: "A protein modification that effectively converts an L-tryptophan residue to a 2'-oxo-L-tryptophan." [PubMed:9461080, RESID:AA0543]
 synonym: "(2S)-2-amino-3-[(3S)-2-oxo-2,3-dihydro-1H-indol-3-yl]propanoic acid" EXACT RESID-systematic []
 synonym: "2'-oxo-L-tryptophan" EXACT RESID-name []
@@ -36434,7 +36455,6 @@ xref: MassMono: "177.009579"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00399 ! iodoacetic acid derivatized residue
 is_a: MOD:00708 ! sulfur oxygenated L-cysteine
 is_a: MOD:01855 ! sulfur dioxygenated residue
 relationship: derives_from MOD:01061 ! S-carboxymethyl-L-cysteine
@@ -36454,7 +36474,6 @@ xref: MassMono: "192.020478"
 xref: Origin: "C"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00397 ! iodoacetamide derivatized residue
 is_a: MOD:00708 ! sulfur oxygenated L-cysteine
 is_a: MOD:01855 ! sulfur dioxygenated residue
 relationship: derives_from MOD:01060 ! S-carboxamidomethyl-L-cysteine
@@ -36497,32 +36516,32 @@ is_a: MOD:01832 ! 5x(13)C-labeled residue
 id: MOD:01834
 name: 5x(13)C-labeled L-methionine sulfoxide
 def: "A protein modification that effectively converts an L-methionine residue containing common isotopes to 5x(13)C-labeled L-methionine sulfoxide." [PubMed:18688235]
-xref: DiffAvg: "21.01"
-xref: DiffFormula: "(12)C -5 (13)C 5 H 0 N 0 O 1 S 0"
-xref: DiffMono: "21.011689"
+xref: DiffAvg: "5.02"
+xref: DiffFormula: "(12)C -5 (13)C 5 H 0 N 0 O 0 S 0"
+xref: DiffMono: "5.016774"
 xref: Formula: "(13)C 5 H 9 N 1 O 2 S 1"
 xref: MassAvg: "152.05"
 xref: MassMono: "152.052174"
-xref: Origin: "M"
+xref: Origin: "MOD:00719"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00719 ! L-methionine sulfoxide
+relationship: derives_from MOD:00719 ! L-methionine sulfoxide
 is_a: MOD:01832 ! 5x(13)C-labeled residue
 
 [Term]
 id: MOD:01835
 name: 5x(13)C-labeled L-methionine sulfone
 def: "A protein modification that effectively converts an L-methionine residue containing common isotopes to 5x(13)C-labeled L-methionine sulfone." [PubMed:18688235]
-xref: DiffAvg: "37.01"
-xref: DiffFormula: "(12)C -5 (13)C 5 H 0 N 0 O 2 S 0"
-xref: DiffMono: "37.006603"
+xref: DiffAvg: "5.02"
+xref: DiffFormula: "(12)C -5 (13)C 5 H 0 N 0 O 0 S 0"
+xref: DiffMono: "5.016774"
 xref: Formula: "(13)C 5 H 9 N 1 O 3 S 1"
 xref: MassAvg: "168.05"
 xref: MassMono: "168.047088"
-xref: Origin: "M"
+xref: Origin: "MOD:00256"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00256 ! L-methionine sulfone
+relationship: derives_from MOD:00256 ! L-methionine sulfone
 is_a: MOD:01832 ! 5x(13)C-labeled residue
 
 [Term]
@@ -36565,7 +36584,7 @@ xref: MassMono: "172.030649"
 xref: Origin: "C, C"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
-is_a: MOD:01839 ! L-lanthionine
+is_a: MOD:00687 ! thioether crosslinked residues
 
 [Term]
 id: MOD:01838
@@ -36609,6 +36628,7 @@ xref: Source: "artifact"
 xref: TermSpec: "none"
 is_a: MOD:00859 ! modified residue that can arise from different natural residues
 is_a: MOD:01841 ! lanthionine
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01840
@@ -36634,6 +36654,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0442"
 is_a: MOD:00664 ! stereoisomerized residue
 is_a: MOD:00910 ! modified L-isoleucine residue
+is_a: MOD:00306 ! residues isobaric at 113.084064 Da
 
 [Term]
 id: MOD:01841
@@ -36657,6 +36678,7 @@ xref: Origin: "C, X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 is_a: MOD:01993 ! beta-carbon thioether crosslinked residues
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01842
@@ -36952,7 +36974,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0628"
 is_a: MOD:00426 ! S-glycosylated residue
-is_a: MOD:00448 ! N-acetylaminoglucosylated residue
+is_a: MOD:00448 ! mono-N-acetylaminoglucosylated residue
 is_a: MOD:00905 ! modified L-cysteine residue
 
 [Term]
@@ -37182,8 +37204,8 @@ xref: Origin: "MOD:01060"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:26"
-is_a: MOD:00397 ! iodoacetamide derivatized residue
-is_a: MOD:00419 ! (R)-5-oxo-1,4-tetrahydrothiazine-3-carboxylic acid
+is_a: MOD:01160 ! deaminated residue
+relationship: contains MOD:00419 ! (R)-5-oxo-1,4-tetrahydrothiazine-3-carboxylic acid
 relationship: derives_from MOD:01060 ! S-carboxamidomethyl-L-cysteine
 
 [Term]
@@ -37207,8 +37229,8 @@ xref: Origin: "MOD:01061"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
 xref: Unimod: "Unimod:26"
-is_a: MOD:00399 ! iodoacetic acid derivatized residue
-is_a: MOD:00419 ! (R)-5-oxo-1,4-tetrahydrothiazine-3-carboxylic acid
+is_a: MOD:00704 ! dehydrated residue
+relationship: contains MOD:00419 ! (R)-5-oxo-1,4-tetrahydrothiazine-3-carboxylic acid
 relationship: derives_from MOD:01061 ! S-carboxymethyl-L-cysteine
 
 [Term]
@@ -37266,9 +37288,7 @@ is_a: MOD:00912 ! modified L-lysine residue
 [Term]
 id: MOD:01876
 name: 4x(1)H,4x(12)C-labeled alpha-amino succinylated residue
-def: "A protein modification that effectively replaces a residue alpha-amino- or alpha-imino-hydrogen with a 4x(12)C labeled succinyl group." [PubMed:11857757, PubMed:12175151, PubMed:12716131, Unimod:64]
-synonym: "Succinic anhydride labeling reagent, light form (+4amu, 4H2) site N-term" RELATED Unimod-description []
-synonym: "Succinyl" RELATED PSI-MS-label []
+def: "OBSOLETE because identical to MOD:00457" [PubMed:18688235]
 xref: DiffAvg: "100.02"
 xref: DiffFormula: "(12)C 4 (1)H 4 O 3"
 xref: DiffMono: "100.016044"
@@ -37278,9 +37298,8 @@ xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "N-term"
-xref: Unimod: "Unimod:64"
-is_a: MOD:00457 ! alpha-amino succinylated residue
-is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+xref: Remap: "MOD:00457"
+is_obsolete: true
 
 [Term]
 id: MOD:01877
@@ -37629,7 +37648,8 @@ xref: Origin: "X"
 xref: Source: "artifact"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:58"
-is_a: MOD:00451 ! alpha-amino propanoylated residue
+relationship: derives_from MOD:00451 ! alpha-amino propanoylated residue
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
 
 [Term]
 id: MOD:01896
@@ -37672,7 +37692,6 @@ xref: UniProt: "PTM-0466"
 is_a: MOD:00601 ! cyclized residue
 is_a: MOD:00679 ! carbon oxygenated residue
 is_a: MOD:00910 ! modified L-isoleucine residue
-is_a: MOD:01888 ! didehydrogenated residue
 is_a: MOD:01905 ! 5-hydroxy-3-methyl-L-proline
 
 [Term]
@@ -37717,7 +37736,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0460"
 is_a: MOD:02041 ! crosslinked L-arginine residue
 is_a: MOD:01420 ! thiazole/thiazoline ring crosslinked residues
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01900
@@ -37740,7 +37759,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0461"
 is_a: MOD:02044 ! crosslinked L-cysteine residue
 is_a: MOD:01422 ! oxazole/oxazoline ring crosslinked residues (Thr)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01901
@@ -37762,7 +37781,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0462"
 is_a: MOD:01422 ! oxazole/oxazoline ring crosslinked residues (Thr)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01902
@@ -37785,7 +37804,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0463"
 is_a: MOD:02049 ! crosslinked L-isoleucine residue
 is_a: MOD:01421 ! oxazole/oxazoline ring crosslinked residues (Ser)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01903
@@ -37807,7 +37826,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0464"
 is_a: MOD:01421 ! oxazole/oxazoline ring crosslinked residues (Ser)
-is_a: MOD:01888 ! didehydrogenated residue
+is_a: MOD:02082 ! didehydrogenated and dehydrated residue
 
 [Term]
 id: MOD:01904
@@ -37831,6 +37850,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0465"
 is_a: MOD:02055 ! crosslinked L-serine residue
 is_a: MOD:01422 ! oxazole/oxazoline ring crosslinked residues (Thr)
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01905
@@ -38002,26 +38022,25 @@ is_a: MOD:01911 ! monochlorinated residue
 [Term]
 id: MOD:01914
 name: O5-galactosyl-L-hydroxylysine
-def: "A protein modification that effectively converts an L-lysine residue to O5-galactosyl-L-hydroxylysine." [PMID:743239, PubMed:17516569, Unimod:907]
+def: "A protein modification that effectively converts a 5-hydroxy-L-lysine residue to O5-galactosyl-L-hydroxylysine." [PMID:743239, PubMed:17516569, Unimod:907]
 comment: Secondary to RESID:AA0028. This intermediate is rarely observed [JSG].
 subset: PSI-MOD-slim
 synonym: "Galactosyl hydroxylysine" RELATED Unimod-description []
 synonym: "OGal5HyLys" EXACT PSI-MOD-label []
 synonym: "CARBOHYD O-linked (Gal) hydroxylysine" EXACT UniProt-feature []
-xref: DiffAvg: "178.14"
-xref: DiffFormula: "C 6 H 10 N 0 O 6"
-xref: DiffMono: "178.047738"
+xref: DiffAvg: "162.14"
+xref: DiffFormula: "C 6 H 10 O 5"
+xref: DiffMono: "162.052823"
 xref: Formula: "C 16 H 22 N 2 O 7"
 xref: MassAvg: "354.36"
 xref: MassMono: "354.142701"
-xref: Origin: "K"
+xref: Origin: "MOD:00037"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:907"
 xref: UniProt: "PTM-0556"
-is_a: MOD:00037 ! 5-hydroxy-L-lysine
+is_a: MOD:00476 ! monogalactosylated residue
 is_a: MOD:00396 ! O-glycosylated residue
-is_a: MOD:00476 ! galactosylated residue
 
 [Term]
 id: MOD:01915
@@ -38063,7 +38082,7 @@ xref: Origin: "Y"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0570"
-is_a: MOD:00563 ! N-acetylaminogalactosylated residue
+is_a: MOD:00563 ! mono-N-acetylaminogalactosylated residue
 is_a: MOD:01927 ! O-glycosyl-L-tyrosine
 
 [Term]
@@ -38090,6 +38109,7 @@ xref: TermSpec: "none"
 xref: UniProt: "PTM-0486"
 is_a: MOD:02043 ! crosslinked L-aspartic acid residue
 is_a: MOD:01929 ! N6-(L-isoaspartyl)-L-lysine
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01918
@@ -38159,6 +38179,7 @@ xref: Origin: "H"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0477"
+is_a: MOD:00909 ! modified L-histidine residue
 is_a: MOD:00677 ! hydroxylated residue
 
 [Term]
@@ -38488,7 +38509,9 @@ xref: Origin: "K"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0572"
-is_a: MOD:01047 ! monohydroxylated lysine
+relationship: derives_from MOD:01047 ! monohydroxylated lysine
+is_a: MOD:00396 ! O-glycosylated residue
+is_a: MOD:00912 ! modified L-lysine residue
 
 [Term]
 id: MOD:01936
@@ -38549,6 +38572,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02042 ! crosslinked L-asparagine residue
 is_a: MOD:01945 ! 2-(2-aminosuccinimidyl)-3-sulfanylpropanoic acid
+is_a: MOD:00946 ! crosslinked residues with loss of ammonia
 
 [Term]
 id: MOD:01939
@@ -38569,6 +38593,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02043 ! crosslinked L-aspartic acid residue
 is_a: MOD:01945 ! 2-(2-aminosuccinimidyl)-3-sulfanylpropanoic acid
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01940
@@ -38589,6 +38614,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02042 ! crosslinked L-asparagine residue
 is_a: MOD:01946 ! 2-(2-aminosuccinimidyl)pentanedioic acid
+is_a: MOD:00946 ! crosslinked residues with loss of ammonia
 
 [Term]
 id: MOD:01941
@@ -38609,6 +38635,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02043 ! crosslinked L-aspartic acid residue
 is_a: MOD:01946 ! 2-(2-aminosuccinimidyl)pentanedioic acid
+is_a: MOD:00954 ! crosslinked residues with loss of water
 
 [Term]
 id: MOD:01942
@@ -38820,6 +38847,7 @@ is_a: MOD:02046 ! crosslinked L-glutamine residue
 is_a: MOD:02056 ! crosslinked L-threonine residue
 is_a: MOD:01979 ! O-(L-isoglutamyl)-L-threonine
 is_a: MOD:00885 ! ester crosslinked residues
+is_a: MOD:00946 ! crosslinked residues with loss of ammonia
 
 [Term]
 id: MOD:01953
@@ -39102,7 +39130,7 @@ xref: MassMono: "175.131068"
 xref: Origin: "K"
 xref: Source: "artifact"
 xref: TermSpec: "none"
-is_a: MOD:00064 ! N6-acetyl-L-lysine
+relationship: derives_from MOD:00064 ! N6-acetyl-L-lysine
 is_a: MOD:01428 ! (13)C isotope tagged reagent
 is_a: MOD:01431 ! (2)H deuterium tagged reagent
 
@@ -39152,7 +39180,7 @@ xref: Origin: "R"
 xref: Source: "natural"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0518"
-is_a: MOD:00448 ! N-acetylaminoglucosylated residue
+is_a: MOD:00448 ! mono-N-acetylaminoglucosylated residue
 is_a: MOD:01980 ! omega-N-glycosyl-L-arginine
 
 [Term]
@@ -39251,7 +39279,6 @@ xref: Origin: "E"
 xref: Source: "hypothetical"
 xref: TermSpec: "none"
 xref: UniProt: "PTM-0478"
-is_a: MOD:00674 ! amidated residue
 is_a: MOD:00906 ! modified L-glutamic acid residue
 
 [Term]
@@ -39971,7 +39998,7 @@ id: MOD:02011
 name: N-oleoylated residue
 def: "A protein modification that effectively replaces a residue amino group with a oleoylamino group." []
 subset: PSI-MOD-slim
-xref: DiffAvg: "264.46"
+xref: DiffAvg: "264.45"
 xref: DiffFormula: "C 18 H 32 N 0 O 1"
 xref: DiffMono: "264.245316"
 xref: Formula: "none"
@@ -39988,7 +40015,7 @@ id: MOD:02012
 name: oleoylated residue
 def: "A protein modification that effectively replaces a hydrogen atom with a oleoyl group." []
 subset: PSI-MOD-slim
-xref: DiffAvg: "264.46"
+xref: DiffAvg: "264.45"
 xref: DiffFormula: "C 18 H 32 N 0 O 1"
 xref: DiffMono: "264.245316"
 xref: Formula: "none"
@@ -40649,8 +40676,8 @@ name: crosslinked D-asparagine residue
 def: "A protein modification that contains an D-asparagine residue crosslinked to one or more amino acid residues." [PubMed:18688235]
 subset: PSI-MOD-slim
 synonym: "XlnkDAsn" EXACT PSI-MOD-label []
-xref: Origin: "N"
-is_a: MOD:00203 ! D-asparagine
+xref: Origin: "MOD:00203"
+is_a: MOD:02097 ! modified D-asparagine residue
 
 [Term]
 id: MOD:02061
@@ -40781,6 +40808,360 @@ def: "A protein modification that contains an L-arginine residue coordinated to 
 subset: PSI-MOD-slim
 xref: Origin: "R"
 is_a: MOD:00902 ! modified L-arginine residue
+
+[Term]
+id: MOD:02077
+name: nitrosylated residue
+def: "A protein modification that effectively replaces a hydrogen atom with an nitrosyl (NO) group." [PubMed:10442087, PubMed:11562475, PubMed:15688001, PubMed:8626764, PubMed:8637569, Unimod:275]
+subset: PSI-MOD-slim
+synonym: "Nitrosyl" RELATED PSI-MS-label []
+xref: DiffAvg: "29.00"
+xref: DiffFormula: "C 0 H -1 N 1 O 1 S 0"
+xref: DiffMono: "28.990164"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:275"
+is_a: MOD:01156 ! protein modification categorized by chemical process
+
+[Term]
+id: MOD:02078
+name: acetylated residue
+def: "A protein modification that effectively replaces one or more hydrogen atoms with one or more acetyl groups." [PubMed:11857757, PubMed:11999733, PubMed:12175151, PubMed:14730666, PubMed:15350136]
+subset: PSI-MOD-slim
+synonym: "Acetyl" RELATED PSI-MS-label []
+synonym: "AcRes" EXACT PSI-MOD-label []
+xref: Origin: "X"
+xref: Source: "artifact"
+xref: TermSpec: "none"
+is_a: MOD:00649 ! acylated residue
+
+[Term]
+id: MOD:02079
+name: diacetylated residue
+def: "A protein modification that effectively replaces one hydrogen atom with one acetyl group." [PubMed:11857757, PubMed:11999733, PubMed:12175151, PubMed:14730666, PubMed:15350136, Unimod:1]
+comment: Amino hydrogens are replaced to produce amides; hydroxyl hydrogens are replaced to produce esters; and hydrosulfanyl (thiol) hydrogens are replaced to produce sulfanyl esters (thiol esters). From DeltaMass: Average Mass: 42
+subset: PSI-MOD-slim
+synonym: "Diacetyl" RELATED PSI-MS-label []
+synonym: "Ac2Res" EXACT PSI-MOD-label []
+xref: DiffAvg: "84.07"
+xref: DiffFormula: "C 4 H 4 N 0 O 2"
+xref: DiffMono: "84.021129"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "artifact"
+xref: TermSpec: "none"
+is_a: MOD:02078 ! acetylated residue
+
+[Term]
+id: MOD:02080
+name: diacetylated L-serine
+def: "A protein modification that effectively converts an L-serine residue to either N-acetyl-L-serine, O-acetyl-L-serine, or N,O-diacetyl-L-serine." [PubMed:18688235]
+subset: PSI-MOD-slim
+synonym: "Ac2Ser" EXACT PSI-MOD-label []
+xref: DiffAvg: "84.07"
+xref: DiffFormula: "C 4 H 4 N 0 O 2"
+xref: DiffMono: "84.021129"
+xref: Formula: "C 7 H 10 N 1 O 4"
+xref: MassAvg: "172.16"
+xref: MassMono: "172.060983"
+xref: Origin: "S"
+xref: Source: "natural"
+is_a: MOD:02079 ! diacetylated residue
+is_a: MOD:00916 ! modified L-serine residue
+
+[Term]
+id: MOD:02081
+name: alpha-amino succinylated residue
+def: "A protein modification that effectively replaces a residue alpha-amino- or alpha-imino-hydrogen with a succinyl group." [PubMed:11857757, PubMed:12175151, Unimod:64#N-term]
+synonym: "Succinyl" RELATED PSI-MS-label []
+xref: DiffAvg: "100.07"
+xref: DiffFormula: "C 4 H 4 O 3"
+xref: DiffMono: "100.016044"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "N-term"
+xref: Unimod: "Unimod:64"
+is_a: MOD:01029 ! succinylated residue
+is_a: MOD:01696 ! alpha-amino acylated residue
+is_a: MOD:01426 ! isotope tagged reagent derivatized residue
+
+[Term]
+id: MOD:02082
+name: didehydrogenated and dehydrated residue
+def: "A protein modification that effectively removes two neutral hydrogen atoms (proton and electron) and a water moiety from a residue." [Unimod:401]
+subset: PSI-MOD-slim
+synonym: "2dHdH2ORes" EXACT PSI-MOD-label []
+xref: DiffAvg: "-20.03"
+xref: DiffFormula: "C 0 H -4 N 0 O -1"
+xref: DiffMono: "-20.026215"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "none"
+xref: TermSpec: "none"
+is_a: MOD:00683 ! dehydrogenated residue
+
+[Term]
+id: MOD:02083
+name: 4alpha-FMN modified residue
+def: "A protein modification that effectively results from forming an adduct with a compound containing a riboflavin phosphate (flavin mononucleotide, FMN) group through the 4-alpha position of FMN." [PubMed:18688235]
+subset: PSI-MOD-slim
+synonym: "4aFMNRes" EXACT PSI-MOD-label []
+xref: DiffFormula: "C 17 H 21 N 4 O 9 P 1"
+xref: DiffAvg: "456.35"
+xref: DiffMono: "456.104615"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+is_a: MOD:00896 ! FMN modified residue
+
+[Term]
+id: MOD:02084
+name: 6-FMN modified residue
+def: "A protein modification that effectively results from forming an adduct with a compound containing a riboflavin phosphate (flavin mononucleotide, FMN) group through the 6 position of FMN." [PubMed:18688235]
+subset: PSI-MOD-slim
+synonym: "6-FMNRes" EXACT PSI-MOD-label []
+xref: DiffAvg: "454.33"
+xref: DiffFormula: "C 17 H 19 N 4 O 9 P 1"
+xref: DiffMono: "454.088965"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+is_a: MOD:00896 ! FMN modified residue
+
+[Term]
+id: MOD:02085
+name: 8alpha-FMN modified residue
+def: "A protein modification that effectively results from forming an adduct with a compound containing a riboflavin phosphate (flavin mononucleotide, FMN) group through the 8-alpha position of FMN." [PubMed:18688235]
+subset: PSI-MOD-slim
+synonym: "8a-FMNRes" EXACT PSI-MOD-label []
+xref: DiffAvg: "454.33"
+xref: DiffFormula: "C 17 H 19 N 4 O 9 P 1"
+xref: DiffMono: "454.088965"
+xref: Formula: "none"
+xref: MassAvg: "none"
+xref: MassMono: "none"
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+is_a: MOD:00896 ! FMN modified residue
+
+[Term]
+id: MOD:02086
+name: brominated phenylalanine
+def: "A protein modification that effectively substitutes a hydrogen atom of an L-phenylalanine residue with a bromine atom." [PubMed:18688235]
+synonym: "BrPhe" EXACT PSI-MOD-label []
+xref: Origin: "F"
+xref: Source: "none"
+xref: TermSpec: "none"
+is_a: MOD:00754 ! brominated residue
+is_a: MOD:01066 ! halogenated phenylalanine
+
+[Term]
+id: MOD:02087
+name: adenosine diphosphoribosyl (ADP-ribosyl) modified residue
+def: "A protein modification that effectively results from forming an adduct with one or more ADP-ribose moieties or to modified residues through formation of a glycosidic bond." [DeltaMass:0]
+subset: PSI-MOD-slim
+synonym: "ADPRibRes" EXACT PSI-MOD-label []
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+is_a: MOD:00701 ! nucleotide or nucleic acid modified residue
+
+[Term]
+id: MOD:02088
+name: natural, standard, encoded residue substitution
+def: "A protein modification that effectively replaces a natural, standard, encoded residue." [PubMed:18688235]
+comment: This represents the replacement of an encoded residue in a polypeptide, and must be combined with the formula or mass of another entry that is the replacement residue to represent a mutation or substitution.
+subset: PSI-MOD-slim
+xref: Origin: "X"
+xref: Source: "natural"
+xref: TermSpec: "none"
+is_a: MOD:00009 ! natural residue
+is_a: MOD:01156 ! protein modification categorized by chemical process
+
+[Term]
+id: MOD:02089
+name: O-(phospho-5'-uridine)-L-serine
+def: "A protein modification that effectively crosslinks an L-serine residue and 5'-phosphouridine through a phosphodiester bond to form O-(phospho-5'-uridine)-L-serine." [DeltaMass:0, PubMed:22504181, Unimod:417#S, ChEBI:156051]
+subset: PSI-MOD-slim
+synonym: "MOD_RES O-UMP-serine" EXACT UniProt-feature []
+synonym: "OUMPSer" EXACT PSI-MOD-label []
+synonym: "PhosphoUridine" RELATED PSI-MS-label []
+xref: DiffAvg: "306.17"
+xref: DiffFormula: "C 9 H 11 N 2 O 8 P 1"
+xref: DiffMono: "306.025302"
+xref: Formula: "C 12 H 16 N 3 O 9 P 1"
+xref: MassAvg: "377.24"
+xref: MassMono: "377.062416"
+xref: Origin: "S"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:417"
+xref: UniProt: "PTM-0501"
+is_a: MOD:00916 ! modified L-serine residue
+is_a: MOD:01166 ! uridylated residue
+
+[Term]
+id: MOD:02090
+name: O-(phospho-5'-uridine)-L-threonine
+def: "A protein modification that effectively modifies an L-threonine residue with 5'-phosphouridine through a phosphodiester bond to form O-(phospho-5'-uridine)-L-threonine." [DeltaMass:0, PubMed:22504181, Unimod:417#T, ChEBI:156052]
+subset: PSI-MOD-slim
+synonym: "MOD_RES O-UMP-threonine" EXACT UniProt-feature []
+synonym: "OUMPThr" EXACT PSI-MOD-label []
+synonym: "PhosphoUridine" RELATED PSI-MS-label []
+xref: DiffAvg: "306.17"
+xref: DiffFormula: "C 9 H 11 N 2 O 8 P 1"
+xref: DiffMono: "306.025302"
+xref: Formula: "C 13 H 18 N 3 O 9 P 1"
+xref: MassAvg: "391.27"
+xref: MassMono: "391.078066"
+xref: Origin: "T"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:417"
+xref: UniProt: "PTM-0502"
+is_a: MOD:00917 ! modified L-threonine residue
+is_a: MOD:01166 ! uridylated residue
+
+[Term]
+id: MOD:02091
+name: O-(phospho-5'-adenosine)-L-serine
+def: "A protein modification that effectively modifies an L-serine residue with 5'-phosphoadenosine through a phosphodiester bond to form O-(phospho-5'-adenosine)-L-serine." [PubMed:21472612, Unimod:405#S]
+subset: PSI-MOD-slim
+synonym: "MOD_RES O-AMP-serine" EXACT UniProt-feature []
+synonym: "Phosphoadenosine" RELATED PSI-MS-label []
+xref: DiffAvg: "329.21"
+xref: DiffFormula: "C 10 H 12 N 5 O 6 P 1"
+xref: DiffMono: "329.052520"
+xref: Formula: "C 13 H 17 N 6 O 8 P 1"
+xref: MassAvg: "416.28"
+xref: MassMono: "416.084549"
+xref: Origin: "S"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:405"
+xref: UniProt: "PTM-0651"
+is_a: MOD:00916 ! modified L-serine residue
+is_a: MOD:01165 ! adenylated residue
+
+[Term]
+id: MOD:02092
+name: S-methylbutanedioic acid-L-cysteine
+def: "A protein modification that effectively converts an L-cysteine residue to form S-methylbutanedioic acid-L-cysteine by alkylation with itaconate through a thioether bond." [PubMed:29590092]
+subset: PSI-MOD-slim
+synonym: "MOD_RES S-(2,3-dicarboxypropyl)cysteine" EXACT UniProt-feature []
+xref: DiffAvg: "130.10"
+xref: DiffFormula: "C 5 H 6 N 0 O 4 P 0 S 0"
+xref: DiffMono: "130.026609"
+xref: Formula: "C 8 H 11 N 1 O 5 P 0 S 1"
+xref: MassAvg: "233.24"
+xref: MassMono: "233.035793"
+xref: Origin: "C"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: UniProt: "PTM-0676"
+is_a: MOD:00905 ! modified L-cysteine residue
+is_a: MOD:00001 ! alkylated residue
+
+[Term]
+id: MOD:02093
+name: N6-(2-hydroxyisobutanoyl)-L-lysine
+def: "A protein modification that effectively converts an L-lysine residue to N6-(2-hydroxyisobutanoyl)-L-lysine." [PubMed:29775581, PubMed:24681537, ChEBI:144968, Unimod:1849]
+synonym: "MOD_RES N6-(2-hydroxyisobutyryl)lysine" EXACT UniProt-feature []
+xref: DiffAvg: "86.09"
+xref: DiffFormula: "C 4 H 6 N 0 O 2"
+xref: DiffMono: "86.036779"
+xref: Formula: "C 10 H 18 N 2 O 3"
+xref: MassAvg: "214.27"
+xref: MassMono: "214.131742"
+xref: Origin: "K"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1849"
+xref: UniProt: "PTM-0638"
+is_a: MOD:01875 ! N6-acylated L-lysine
+
+[Term]
+id: MOD:02094
+name: N6-((3R)-3-hydroxybutanoyl)-L-lysine
+def: "A protein modification that effectively converts an L-lysine residue to N6-((3R)-3-hydroxybutanoyl)-L-lysine." [PubMed:27105115, ChEBI:149490]
+synonym: "MOD_RES N6-(beta-hydroxybutyryl)lysine" EXACT UniProt-feature []
+xref: DiffAvg: "86.09"
+xref: DiffFormula: "C 4 H 6 N 0 O 2"
+xref: DiffMono: "86.036779"
+xref: Formula: "C 10 H 18 N 2 O 3"
+xref: MassAvg: "214.27"
+xref: MassMono: "214.131742"
+xref: Origin: "K"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: UniProt: "PTM-0499"
+is_a: MOD:01875 ! N6-acylated L-lysine
+
+[Term]
+id: MOD:02095
+name: N6-glutaryl-L-lysine
+def: "A protein modification that effectively converts an L-lysine residue to N6-glutaryl-L-lysine." [PubMed:24703693, ChEBI:87828]
+synonym: "MOD_RES N6-glutaryllysine" EXACT UniProt-feature []
+xref: DiffAvg: "114.10"
+xref: DiffFormula: "C 5 H 6 N 0 O 3"
+xref: DiffMono: "114.031694"
+xref: Formula: "C 11 H 18 N 2 O 4"
+xref: MassAvg: "242.28"
+xref: MassMono: "242.126657"
+xref: Origin: "K"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: UniProt: "PTM-0487"
+is_a: MOD:01875 ! N6-acylated L-lysine
+
+[Term]
+id: MOD:02096
+name: N4-methyl-D-asparagine
+def: "A protein modification that effectively converts a D-asparagine residue to N4-methyl-D-asparagine." [PubMed:22983711, ChEBI:149514]
+subset: PSI-MOD-slim
+synonym: "MOD_RES N4-methyl-D-asparagine" EXACT UniProt-feature []
+synonym: "N4-methylated D-asparagine" EXACT PSI-MOD-alternate []
+xref: DiffAvg: "14.03"
+xref: DiffFormula: "C 1 H 2 N 0 O 0"
+xref: DiffMono: "14.015650"
+xref: Formula: "C 5 H 8 N 2 O 2"
+xref: MassAvg: "128.13"
+xref: MassMono: "128.058578"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: UniProt: "PTM-0691"
+is_a: MOD:00599 ! monomethylated residue
+is_a: MOD:00602 ! N-methylated residue
+is_a: MOD:00673 ! methylated asparagine
+is_a: MOD:02097 ! modified D-asparagine residue
+is_a: MOD:00894 ! residues isobaric at 128.058578 Da
+
+[Term]
+id: MOD:02097
+name: modified D-asparagine residue
+def: "A protein modification that modifies a D-asparagine residue." [PubMed:18688235]
+subset: PSI-MOD-slim
+synonym: "ModDAsn" EXACT PSI-MOD-label []
+is_a: MOD:00203 ! D-asparagine
 
 [Typedef]
 id: contains


### PR DESCRIPTION
* switches mass descriptors to standardize on 4 decimal places
* updates PSI-MOD OBO to 1.031.2 to fixed identical  name problem on tests