### PR TITLE
MzIdentML Parser Improvements

### DIFF
--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlAnalysisCollection.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlAnalysisCollection.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TopDownProteomics.IO.MzIdentMl
+{
+	internal class MzIdentMlAnalysisCollection
+	{
+		public MzIdentMlAnalysisCollection(List<MzIdentMlSpectrumIdentification> spectrumIdentifications, List<MzIdentMlProteinDetection> proteinDetections)
+		{
+			SpectrumIdentifications = spectrumIdentifications;
+			ProteinDetections = proteinDetections;
+		}
+
+		public List<MzIdentMlSpectrumIdentification> SpectrumIdentifications { get; }
+		public List<MzIdentMlProteinDetection> ProteinDetections { get; }
+	}
+}

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlDatabaseSequence.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlDatabaseSequence.cs
@@ -2,10 +2,10 @@
 
 namespace TopDownProteomics.IO.MzIdentMl
 {
-	/// <summary>
-	/// Corresponds to the DBSequence element
-	/// </summary>
-	public class MzIdentMlDatabaseSequence
+    /// <summary>
+    /// Corresponds to the DBSequence element
+    /// </summary>
+    public class MzIdentMlDatabaseSequence
     {
         /// <summary>
         /// Instantiates with the required parameters
@@ -14,11 +14,11 @@ namespace TopDownProteomics.IO.MzIdentMl
         /// <param name="accession"></param>
         /// <param name="searchDatabaseId"></param>
 		public MzIdentMlDatabaseSequence(string id, string accession, string searchDatabaseId)
-		{
+        {
             this.Id = id;
             this.Accession = accession;
             this.SearchDatabaseId = searchDatabaseId;
-		}
+        }
 
         /// <summary>
         /// Gets and sets the Id
@@ -54,5 +54,20 @@ namespace TopDownProteomics.IO.MzIdentMl
         /// Gets and sets the userParams
         /// </summary>
 		public List<MzIdentMlUserParam>? UserParams { get; set; }
+
+        /// <summary>
+        /// Gets and sets the protein description
+        /// </summary>
+        public string? ProteinDescription { get; set; }
+
+        /// <summary>
+        /// Gets and sets the taxonomy scientific name
+        /// </summary>
+        public string? TaxonomyScientificName { get; set; }
+
+        /// <summary>
+        /// Gets and sets the taxon ID
+        /// </summary>
+        public int? TaxonId { get; set; }
 	}
 }

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlFragmentArray.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlFragmentArray.cs
@@ -8,18 +8,18 @@
 		/// <summary>
 		/// Instantiates with required parameters
 		/// </summary>
-		/// <param name="measureId"></param>
+		/// <param name="measure"></param>
 		/// <param name="values"></param>
-		public MzIdentMlFragmentArray(string measureId, double[] values)
+		public MzIdentMlFragmentArray(MzIdentMlFragmentationMeasure measure, double[] values)
 		{
-			this.MeasureId = measureId;
+			this.Measure = measure;
 			this.Values = values;
 		}
 
 		/// <summary>
-		/// Gets the measure Id
+		/// Gets the measure
 		/// </summary>
-		public string MeasureId { get; }
+		public MzIdentMlFragmentationMeasure Measure { get; }
 
 		/// <summary>
 		/// Gets the values

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlIonType.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlIonType.cs
@@ -39,6 +39,21 @@ namespace TopDownProteomics.IO.MzIdentMl
 		public List<MzIdentMlFragmentArray>? FragmentArrays { get; set; }
 
 		/// <summary>
+		/// Gets and sets the m/z array
+		/// </summary>
+		public MzIdentMlFragmentArray? MzArray { get; set; }
+
+		/// <summary>
+		/// Gets and sets the m/z error array
+		/// </summary>
+		public MzIdentMlFragmentArray? MzErrorArray { get; set; }
+
+		/// <summary>
+		/// Gets and sets the intensity array
+		/// </summary>
+		public MzIdentMlFragmentArray? IntensityArray { get; set; }
+
+		/// <summary>
 		/// Gets the userParams
 		/// </summary>
 		public List<MzIdentMlUserParam>? UserParams { get; set; }

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlParser.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlParser.cs
@@ -825,7 +825,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 
 			MzIdentMlSpectraData spectraData = GetInputsAux(reader).SpectraData;
 
-			List<MzIdentMlSpectrumIdentificationList> spectrumIdLists = new();
+			List<MzIdentMlSpectrumIdentificationList> spectrumIdLists = new List<MzIdentMlSpectrumIdentificationList>();
 
 			while (reader.Read())
 			{
@@ -850,8 +850,8 @@ namespace TopDownProteomics.IO.MzIdentMl
 
 		private MzIdentMlAnalysisCollection GetAnalysisCollection(XmlReader reader)
 		{
-			List<MzIdentMlSpectrumIdentification> spectrumIds = new();
-			List<MzIdentMlProteinDetection> proteinDetections = new();
+			List<MzIdentMlSpectrumIdentification> spectrumIds = new List<MzIdentMlSpectrumIdentification>();
+			List<MzIdentMlProteinDetection> proteinDetections = new List<MzIdentMlProteinDetection>();
 			do
 			{
 				if (reader.Name == "AnalysisCollection" && reader.NodeType == XmlNodeType.EndElement)
@@ -948,8 +948,8 @@ namespace TopDownProteomics.IO.MzIdentMl
 
 			bool hasSequencedSearched = int.TryParse(reader.GetAttribute("numSequencesSearched"), out int numSequencesSearched);
 
-			Dictionary<string, MzIdentMlFragmentationMeasure> measures = new();
-			List<MzIdentMlSpectrumIdentificationResult> results = new();
+			Dictionary<string, MzIdentMlFragmentationMeasure> measures = new Dictionary<string, MzIdentMlFragmentationMeasure>();
+			List<MzIdentMlSpectrumIdentificationResult> results = new List<MzIdentMlSpectrumIdentificationResult>();
 
 			while (reader.Read())
 			{
@@ -978,7 +978,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 		private MzIdentMlProteinDetectionProtocol GetProteinDetectionProtocol(MzIdentMlAnalysisCollection analysisCollection, IEnumerable<MzIdentMlProteinDetectionProtocol> proteinProtocols, string spectrumListId)
 		{
 			string? proteinProtocolId = analysisCollection.ProteinDetections.FirstOrDefault(x => x.SpectrumIdentificationListId == spectrumListId).ProteinDetectionProtocolId;
-			if (proteinProtocolId is not null)
+			if (proteinProtocolId != null)
 			{
 				return proteinProtocols.FirstOrDefault(x => x.Id == proteinProtocolId);
 			}
@@ -990,7 +990,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 		{
 
 			string? spectrumProtocolId = analysisCollection.SpectrumIdentifications.FirstOrDefault(x => x.SpectrumIdentificationListId == spectrumListId).SpectrumIdentificationProtocolId;
-			if (spectrumProtocolId is not null)
+			if (spectrumProtocolId != null)
 			{
 				return spectrumProtocols.FirstOrDefault(x => x.Id == spectrumProtocolId);
 			}

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlParser.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlParser.cs
@@ -1120,7 +1120,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 			return spectrumId;
 		}
 
-		private MzIdentMlIonType ParseIonType(XmlReader reader, Dictionary<string, MzIdentMlFragmentationMeasure>? measures)
+		private MzIdentMlIonType ParseIonType(XmlReader reader, Dictionary<string, MzIdentMlFragmentationMeasure> measures)
 		{
 			var indices = this.ParseIonTypeIndices(reader.GetAttribute("index"));
 			var chargeAttribute = reader.GetAttribute("charge");
@@ -1192,7 +1192,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 			}
 		}
 
-		private MzIdentMlFragmentArray ParseFragmentArray(XmlReader reader, Dictionary<string, MzIdentMlFragmentationMeasure>? measures)
+		private MzIdentMlFragmentArray ParseFragmentArray(XmlReader reader, Dictionary<string, MzIdentMlFragmentationMeasure> measures)
 		{
 			double[] values = this.ParseFragmentValues(reader.GetAttribute("values"));
 			var measureId = reader.GetAttribute("measure_ref");
@@ -1200,9 +1200,9 @@ namespace TopDownProteomics.IO.MzIdentMl
 			if (values.Length == 0 || string.IsNullOrEmpty(measureId))
 				throw new Exception("FragmentArray elements must contain values and a measure_ref");
 
-			if (measures?.TryGetValue(measureId, out MzIdentMlFragmentationMeasure measure) == true)
+			if (measures.ContainsKey(measureId))
 			{
-				return new MzIdentMlFragmentArray(measure, values);
+				return new MzIdentMlFragmentArray(measures[measureId], values);
 			}
 
 			throw new Exception($"Unable to find measure for {measureId}");

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlPeptide.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlPeptide.cs
@@ -16,7 +16,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 		{
             this.Id = id;
             this.Sequence = sequence;
-        }
+		}
 
         /// <summary>
         /// Gets the id

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlPeptideEvidence.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlPeptideEvidence.cs
@@ -10,28 +10,28 @@ namespace TopDownProteomics.IO.MzIdentMl
         /// <summary>
         /// Instantiates with schema-required parameters
         /// </summary>
-        /// <param name="databaseSequenceId"></param>
+        /// <param name="databaseSequence"></param>
         /// <param name="id"></param>
-        /// <param name="peptideId"></param>
-		public MzIdentMlPeptideEvidence(string databaseSequenceId, string id, string peptideId)
+        /// <param name="peptide"></param>
+		public MzIdentMlPeptideEvidence(MzIdentMlDatabaseSequence databaseSequence, string id, MzIdentMlPeptide peptide)
 		{
-            this.DatabaseSequenceId = databaseSequenceId;
+            this.DatabaseSequence = databaseSequence;
             this.Id = id;
-            this.PeptideId = peptideId;
+            this.Peptide = peptide;
 		}
 
         /// <summary>
-        /// Gets and sets the database sequence id
+        /// Gets the database sequence
         /// </summary>
-        public string DatabaseSequenceId { get; }
+        public MzIdentMlDatabaseSequence DatabaseSequence { get; }
 
         /// <summary>
-        /// Gets and sets the peptide id
+        /// Gets  the peptide
         /// </summary>
-        public string PeptideId { get; }
+        public MzIdentMlPeptide Peptide { get; }
 
         /// <summary>
-        /// Gets and sets the id
+        /// Gets the id
         /// </summary>
         public string Id { get; }
 

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlPeptideHypothesis.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlPeptideHypothesis.cs
@@ -11,11 +11,11 @@ namespace TopDownProteomics.IO.MzIdentMl
 		/// Instantiates with schema-required parameters
 		/// </summary>
 		/// <param name="peptideEvidenceId"></param>
-		/// <param name="spectrumIdentificationItemId"></param>
-		public MzIdentMlPeptideHypothesis(string peptideEvidenceId, string spectrumIdentificationItemId)
+		/// <param name="spectrumIdentificationItemIds"></param>
+		public MzIdentMlPeptideHypothesis(string peptideEvidenceId, List<string> spectrumIdentificationItemIds)
 		{
 			this.PeptideEvidenceId = peptideEvidenceId;
-			this.SpectrumIdentificationItemId = spectrumIdentificationItemId;
+			this.SpectrumIdentificationItemIds = spectrumIdentificationItemIds;
 		}
 
 		/// <summary>
@@ -26,7 +26,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 		/// <summary>
 		/// Gets the SpectrumIdentification ids
 		/// </summary>
-		public string SpectrumIdentificationItemId { get; }
+		public List<string> SpectrumIdentificationItemIds { get; }
 
 		/// <summary>
 		/// Gets and sets the cvParams

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlProteinDetection.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlProteinDetection.cs
@@ -1,0 +1,18 @@
+﻿namespace TopDownProteomics.IO.MzIdentMl
+{
+	internal class MzIdentMlProteinDetection
+	{
+		public MzIdentMlProteinDetection(string id, string proteinDetectionProtocolId, string proteinDetectionListId, string spectrumIdentificationListId)
+		{
+			Id = id;
+			ProteinDetectionProtocolId = proteinDetectionProtocolId;
+			ProteinDetectionListId = proteinDetectionListId;
+			SpectrumIdentificationListId = spectrumIdentificationListId;
+		}
+
+		public string Id { get; }
+		public string ProteinDetectionProtocolId { get; }
+		public string ProteinDetectionListId { get; }
+		public string SpectrumIdentificationListId { get; }
+	}
+}

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSearchDatabase.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSearchDatabase.cs
@@ -12,14 +12,10 @@ namespace TopDownProteomics.IO.MzIdentMl
 		/// </summary>
 		/// <param name="id"></param>
 		/// <param name="location"></param>
-		/// <param name="fileFormat"></param>
-		/// <param name="databaseName"></param>
-		public MzIdentMlSearchDatabase(string id, string location, MzIdentMlCvParam fileFormat, MzIdentMlCvOrUserParam databaseName)
+		public MzIdentMlSearchDatabase(string id, string location)
 		{
 			this.Id = id;
 			this.Location = location;
-			this.FileFormat = fileFormat;
-			this.DatabaseName = databaseName;
 		}
 
 		/// <summary>
@@ -35,7 +31,7 @@ namespace TopDownProteomics.IO.MzIdentMl
 		/// <summary>
 		/// Gets and sets the database name
 		/// </summary>
-		public MzIdentMlCvOrUserParam DatabaseName { get; }
+		public MzIdentMlCvOrUserParam? DatabaseName { get; set; }
 
 		/// <summary>
 		/// Gets and sets the name

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentification.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentification.cs
@@ -1,0 +1,20 @@
+﻿namespace TopDownProteomics.IO.MzIdentMl
+{
+	internal class MzIdentMlSpectrumIdentification
+	{
+		public MzIdentMlSpectrumIdentification(string id, string spectrumIdentificationProtocolId, string spectrumIdentificationListId, string inputSpectraId, string searchDatabaseId)
+		{
+			Id = id;
+			SpectrumIdentificationProtocolId = spectrumIdentificationProtocolId;
+			SpectrumIdentificationListId = spectrumIdentificationListId;
+			InputSpectraId = inputSpectraId;
+			SearchDatabaseId = searchDatabaseId;
+		}
+
+		public string Id { get; }
+		public string SpectrumIdentificationProtocolId { get; }
+		public string SpectrumIdentificationListId { get; }
+		public string InputSpectraId { get; }
+		public string SearchDatabaseId { get; }
+	}
+}

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationItem.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace TopDownProteomics.IO.MzIdentMl
 {
@@ -16,8 +17,8 @@ namespace TopDownProteomics.IO.MzIdentMl
 		/// <param name="experimentalMz"></param>
 		/// <param name="passesThreshold"></param>
 		/// <param name="rank"></param>
-		/// <param name="peptideEvidenceIds"></param>
-		public MzIdentMlSpectrumIdentificationItem(string id, int chargeState, double calculatedMz, double experimentalMz, bool passesThreshold, int rank, List<string> peptideEvidenceIds)
+		/// <param name="peptideEvidences"></param>
+		public MzIdentMlSpectrumIdentificationItem(string id, int chargeState, double calculatedMz, double experimentalMz, bool passesThreshold, int rank, List<MzIdentMlPeptideEvidence> peptideEvidences)
 		{
 			this.Id = id;
 			this.ChargeState = chargeState;
@@ -25,7 +26,8 @@ namespace TopDownProteomics.IO.MzIdentMl
 			this.ExperimentalMz = experimentalMz;
 			this.PassesThreshold = passesThreshold;
 			this.Rank = rank;
-			this.PeptideEvidenceIds = peptideEvidenceIds;
+			this.PeptideEvidences = peptideEvidences;
+			this.Peptides = this.PeptideEvidences.Select(x => x.Peptide).ToList();
 		}
 
 		/// <summary>
@@ -59,19 +61,14 @@ namespace TopDownProteomics.IO.MzIdentMl
 		public bool PassesThreshold { get; }
 
 		/// <summary>
-		/// Gets and sets the peptide evidence ids
-		/// </summary>
-		public List<string> PeptideEvidenceIds { get; }
-
-		/// <summary>
 		/// Gets and sets the peptide evidences
 		/// </summary>
-		public List<MzIdentMlPeptideEvidence>? PeptideEvidences { get; set; }
+		public List<MzIdentMlPeptideEvidence> PeptideEvidences { get; }
 
 		/// <summary>
 		/// Gets and sets the proteoforms
 		/// </summary>
-		public List<MzIdentMlPeptide>? Peptides { get; set; }
+		public List<MzIdentMlPeptide> Peptides { get; set; }
 
 		/// <summary>
 		/// Gets and sets the ion types

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationList.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationList.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TopDownProteomics.IO.MzIdentMl
+{
+	/// <summary>
+	/// A collection of spectrum identifications
+	/// </summary>
+	public class MzIdentMlSpectrumIdentificationList
+	{
+		/// <summary>
+		/// Creates a spectrum identification list
+		/// </summary>
+		/// <param name="id"></param>
+		/// <param name="measures"></param>
+		/// <param name="spectrumIdentificationResults"></param>
+		/// <param name="proteinDetectionProtocol"></param>
+		/// <param name="spectrumIdentificationProtocol"></param>
+		/// <param name="name"></param>
+		/// <param name="sequencesSearched"></param>
+		public MzIdentMlSpectrumIdentificationList(string id, List<MzIdentMlFragmentationMeasure> measures, List<MzIdentMlSpectrumIdentificationResult> spectrumIdentificationResults, MzIdentMlProteinDetectionProtocol proteinDetectionProtocol, MzIdentMlSpectrumIdentificationProtocol spectrumIdentificationProtocol, string? name = null, int? sequencesSearched = null)
+		{
+			Id = id;
+			Measures = measures;
+			SpectrumIdentificationResults = spectrumIdentificationResults;
+			ProteinDetectionProtocol = proteinDetectionProtocol;
+			SpectrumIdentificationProtocol = spectrumIdentificationProtocol;
+			Name = name;
+			SequencesSearched = sequencesSearched;
+		}
+
+		/// <summary>
+		/// Gets the ID
+		/// </summary>
+		public string Id { get; }
+
+		/// <summary>
+		/// Gets the measures
+		/// </summary>
+		public List<MzIdentMlFragmentationMeasure> Measures { get; }
+
+		/// <summary>
+		/// Gets the spectrum identification results
+		/// </summary>
+		public List<MzIdentMlSpectrumIdentificationResult> SpectrumIdentificationResults { get; }
+
+		/// <summary>
+		/// Gets the protein detection protocol
+		/// </summary>
+		public MzIdentMlProteinDetectionProtocol ProteinDetectionProtocol { get; }
+
+		/// <summary>
+		/// Gets the spectrum identification protocol
+		/// </summary>
+		public MzIdentMlSpectrumIdentificationProtocol SpectrumIdentificationProtocol { get; }
+
+		/// <summary>
+		/// Gets the name
+		/// </summary>
+		public string? Name { get; }
+
+		/// <summary>
+		/// Gets the number of sequences searched
+		/// </summary>
+		public int? SequencesSearched { get; }
+	}
+}

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationProtocol.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationProtocol.cs
@@ -5,19 +5,21 @@
 	/// </summary>
 	public class MzIdentMlSpectrumIdentificationProtocol
     {
-        /// <summary>
-        /// Instantiates with required parameters
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="softwareId"></param>
-        /// <param name="searchType"></param>
-        /// <param name="thresholds"></param>
-		public MzIdentMlSpectrumIdentificationProtocol(string id, string softwareId, MzIdentMlCvOrUserParam searchType, MzIdentMlParamCollection thresholds)
+		/// <summary>
+		/// Instantiates with required parameters
+		/// </summary>
+		/// <param name="id"></param>
+		/// <param name="softwareId"></param>
+		/// <param name="searchType"></param>
+		/// <param name="thresholds"></param>
+		/// <param name="name"></param>
+		public MzIdentMlSpectrumIdentificationProtocol(string id, string softwareId, MzIdentMlCvOrUserParam searchType, MzIdentMlParamCollection thresholds, string? name = null)
 		{
             this.Id = id;
             this.SoftwareId = softwareId;
             this.SearchType = searchType;
             this.Thresholds = thresholds;
+			this.Name = name;
 		}
         /// <summary>
         /// Gets and sets the id
@@ -58,5 +60,10 @@
         /// Gets the thresholds
         /// </summary>
         public MzIdentMlParamCollection Thresholds { get; }
-    }
+
+        /// <summary>
+        /// Gets the name
+        /// </summary>
+		public string? Name { get; }
+	}
 }

--- a/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationResult.cs
+++ b/src/TopDownProteomics/IO/MzIdentMl/MzIdentMlSpectrumIdentificationResult.cs
@@ -12,32 +12,46 @@ namespace TopDownProteomics.IO.MzIdentMl
 		/// </summary>
 		/// <param name="id"></param>
 		/// <param name="spectrumId"></param>
+		/// <param name="spectrumScanNumber"></param>
+		/// <param name="spectralData"></param>
 		/// <param name="inputSpectraDataId"></param>
 		/// <param name="spectrumIdentificationItems"></param>
-		public MzIdentMlSpectrumIdentificationResult(string id, string spectrumId, string inputSpectraDataId, List<MzIdentMlSpectrumIdentificationItem> spectrumIdentificationItems)
+		public MzIdentMlSpectrumIdentificationResult(string id, string spectrumId, int? spectrumScanNumber, MzIdentMlSpectraData spectralData, string inputSpectraDataId, List<MzIdentMlSpectrumIdentificationItem> spectrumIdentificationItems)
 		{
-			this.Id = id;
-			this.SpectrumId = spectrumId;
-			this.InputSpectraDataId = inputSpectraDataId;
-			this.SpectrumIdentificationItems = spectrumIdentificationItems;
+			Id = id;
+			SpectrumId = spectrumId;
+			SpectrumScanNumber = spectrumScanNumber;
+			SpectralData = spectralData;
+			InputSpectraDataId = inputSpectraDataId;
+			SpectrumIdentificationItems = spectrumIdentificationItems;
 		}
 		/// <summary>
-		/// Gets and sets the id
+		/// Gets the id
 		/// </summary>
 		public string Id { get; }
 
 		/// <summary>
-		/// Gets and sets the spectrum id
+		/// Gets the spectrum id
 		/// </summary>
 		public string SpectrumId { get; }
 
 		/// <summary>
-		/// Gets and sets the input spectra data id
+		/// Gets  the spectrum id
+		/// </summary>
+		public int? SpectrumScanNumber { get; }
+
+		/// <summary>
+		/// Gets the spectral data
+		/// </summary>
+		public MzIdentMlSpectraData SpectralData { get; }
+
+		/// <summary>
+		/// Gets the input spectra data id
 		/// </summary>
 		public string InputSpectraDataId { get; }
 
 		/// <summary>
-		/// Gets and sets the spectrum identification items
+		/// Gets the spectrum identification items
 		/// </summary>
 		public List<MzIdentMlSpectrumIdentificationItem> SpectrumIdentificationItems { get; }
 

--- a/tests/TopDownProteomics.Tests/IO/MzIdentMlTest.cs
+++ b/tests/TopDownProteomics.Tests/IO/MzIdentMlTest.cs
@@ -12,6 +12,32 @@ namespace TopDownProteomics.Tests.IO
 	public class MzIdentMlTest
 	{
 		public static string GetFilePath() => Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "MzIdentMl.mzid");
+		internal static string GoldenPath => Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "golden.mzid");
+
+		[Test]
+		public void MultipleSpectrumIdentificationProtocolsTest()
+		{
+			using (var parser = new MzIdentMlParser(GoldenPath))
+			{
+				var softwares = parser.GetAnalysisSoftware().ToList();
+				var databaseSequences = parser.GetDatabaseSequences().ToList();
+				var dbSequence = databaseSequences[0];
+				var peptides = parser.GetPeptides().ToList();
+				var pep = peptides[0];
+				var evidences = parser.GetPeptideEvidences().ToList();
+				var ev = evidences[0];
+				var inputs = parser.GetInputs();
+				var database = inputs.SearchDatabases[0];
+				var measures = parser.GetFragmentationMeasures().ToList();
+				var meas = measures[0];
+				var proteinDetectionList = parser.GetProteinDetectionList();
+				var proteinProtocols = parser.GetProteinDetectionProtocols().ToList();
+				var spectrumIds = parser.GetSpectrumIdentificationItems().ToList();
+				var id = spectrumIds[0];
+				var spectrumProtocols = parser.GetSpectrumIdentificationProtocols().ToList();
+				var protocol = spectrumProtocols[0];
+			}
+		}
 
 		[Test]
 		public void BasicTest()
@@ -167,7 +193,6 @@ namespace TopDownProteomics.Tests.IO
 				Assert.AreEqual("AS_mascot_server", protocol.SoftwareId);
 				Assert.AreEqual(1, protocol.Thresholds.CvParams.Count);
 			}
-
 		}
 	}
 }

--- a/tests/TopDownProteomics.Tests/IO/MzIdentMlTest.cs
+++ b/tests/TopDownProteomics.Tests/IO/MzIdentMlTest.cs
@@ -6,36 +6,106 @@ using System.Linq;
 using System.Text;
 using TopDownProteomics.IO.MzIdentMl;
 
+
+#nullable enable
+
 namespace TopDownProteomics.Tests.IO
 {
 	[TestFixture]
 	public class MzIdentMlTest
 	{
 		public static string GetFilePath() => Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "MzIdentMl.mzid");
-		internal static string GoldenPath => Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "golden.mzid");
+		internal static string GoldenTDPortalPath => Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "golden.mzid");
 
 		[Test]
 		public void MultipleSpectrumIdentificationProtocolsTest()
 		{
-			using (var parser = new MzIdentMlParser(GoldenPath))
+			using (var parser = new MzIdentMlParser(GoldenTDPortalPath))
 			{
-				var softwares = parser.GetAnalysisSoftware().ToList();
-				var databaseSequences = parser.GetDatabaseSequences().ToList();
-				var dbSequence = databaseSequences[0];
-				var peptides = parser.GetPeptides().ToList();
-				var pep = peptides[0];
-				var evidences = parser.GetPeptideEvidences().ToList();
-				var ev = evidences[0];
-				var inputs = parser.GetInputs();
-				var database = inputs.SearchDatabases[0];
-				var measures = parser.GetFragmentationMeasures().ToList();
-				var meas = measures[0];
-				var proteinDetectionList = parser.GetProteinDetectionList();
-				var proteinProtocols = parser.GetProteinDetectionProtocols().ToList();
-				var spectrumIds = parser.GetSpectrumIdentificationItems().ToList();
-				var id = spectrumIds[0];
-				var spectrumProtocols = parser.GetSpectrumIdentificationProtocols().ToList();
-				var protocol = spectrumProtocols[0];
+				List<MzIdentMlAnalysisSoftware> software = parser.GetAnalysisSoftware().ToList();
+				Assert.AreEqual(software.Count, 1);
+				Assert.AreEqual(software[0].Name, "TDPortal");
+				Assert.AreEqual(software[0].Version, "4.0.0");
+
+				List<MzIdentMlDatabaseSequence> sequences = parser.GetDatabaseSequences().ToList();
+				Assert.AreEqual(sequences.Count, 186);
+				Assert.AreEqual(sequences[0].Accession, "Q9P0S9");
+
+				List <MzIdentMlFragmentationMeasure> measures = parser.GetFragmentationMeasures().ToList();
+				Assert.AreEqual(measures.Count, 2);
+				Assert.AreEqual(measures[0].Measure.Accession, MzIdentMlParser.ProductIonMzCvAccession);
+				Assert.AreEqual(measures[1].Measure.Accession, MzIdentMlParser.ProductIonMzErrorCvAccession);
+
+				MzIdentMlInputs inputs = parser.GetInputs();
+				Assert.AreEqual(inputs.SearchDatabases.Count, 1);
+				Assert.AreEqual(inputs.SourceFiles.Count, 1);
+				Assert.AreEqual(inputs.SpectraData.Location, @"/projects/b1035/scratch/staging_prod_github/10054/working//Rawfiles/golden.raw");
+
+				List <MzIdentMlPeptideEvidence> evidences = parser.GetPeptideEvidences().ToList();
+				Assert.AreEqual(evidences.Count, 346);
+				Assert.AreEqual(evidences[0].Id, "PE_Chem_1730_ISO_1513");
+				Assert.AreEqual(evidences[0].Peptide.Id, "Chem_1730");
+
+				List <MzIdentMlPeptide> peptides = parser.GetPeptides().ToList();
+				Assert.AreEqual(peptides.Count, 345);
+				Assert.AreEqual(peptides[0].Id, "Chem_1730");
+				Assert.AreEqual(peptides[0].PeptideEvidences.Count, 1);
+
+				List<MzIdentMlProteinDetectionList> proteinDetectionLists = parser.GetProteinDetectionLists().ToList();
+				Assert.AreEqual(proteinDetectionLists.Count, 2);
+				Assert.AreEqual(proteinDetectionLists[0].Name, "BioMarker");
+				Assert.AreEqual(proteinDetectionLists[0].ProteinAmbiguityGroups.Count, 121);
+				Assert.AreEqual(proteinDetectionLists[1].ProteinAmbiguityGroups.Count, 169);
+
+				List <MzIdentMlProteinDetectionProtocol> proteinDetectionProtocols = parser.GetProteinDetectionProtocols().ToList();
+				Assert.AreEqual(proteinDetectionProtocols.Count, 2);
+				Assert.AreEqual(proteinDetectionProtocols[0].AnalysisParams.UserParams.Count, 10);
+
+				List<MzIdentMlSpectrumIdentificationItem> spectrumIdItems = parser.GetSpectrumIdentificationItems().ToList();
+				Assert.AreEqual(spectrumIdItems.Count, 1461);
+				Assert.AreEqual(spectrumIdItems[0].PeptideEvidences[0].Id, "PE_Chem_1730_ISO_1513");
+				Assert.AreEqual(spectrumIdItems[0].Peptides[0].Id, "Chem_1730");
+
+				List<MzIdentMlSpectrumIdentificationList> spectrumIdLists = parser.GetSpectrumIdentificationLists().ToList();
+				Assert.AreEqual(spectrumIdLists.Count, 2);
+				Assert.AreEqual(spectrumIdLists[0].Name, "BioMarker");
+				Assert.AreEqual(spectrumIdLists[0].SpectrumIdentificationResults.Count, 401);
+				Assert.AreEqual(spectrumIdLists[1].Name, "Tight Absolute Mass");
+				Assert.AreEqual(spectrumIdLists[1].SpectrumIdentificationResults.Count, 571);
+
+
+				Assert.AreEqual(spectrumIdLists[1].SpectrumIdentificationResults[0].SpectralData.Location, @"/projects/b1035/scratch/staging_prod_github/10054/working//Rawfiles/golden.raw");
+				Assert.AreEqual(spectrumIdLists[1].SpectrumIdentificationResults[0].SpectrumScanNumber, 1426);
+				Assert.AreEqual(spectrumIdLists[1].SpectrumIdentificationResults[4].Id, "SIR_2_1_1032");
+				Assert.AreEqual(spectrumIdLists[1].SpectrumIdentificationResults[4].SpectrumIdentificationItems.Count, 2);
+
+				List <MzIdentMlSpectrumIdentificationProtocol> spectrumIdProtocols = parser.GetSpectrumIdentificationProtocols().ToList();
+				Assert.AreEqual(spectrumIdProtocols.Count, 2);
+				Assert.AreEqual(spectrumIdProtocols[0].Name, "BioMarker");
+				Assert.AreEqual(spectrumIdProtocols[0].SearchParams.UserParams.Count, 101);
+			}
+		}
+
+		[Test]
+		public void ParsedFragmentArraysTest()
+		{
+			using (var parser = new MzIdentMlParser(GoldenTDPortalPath))
+			{
+				List<MzIdentMlSpectrumIdentificationItem> spectrumIdItems = parser.GetSpectrumIdentificationItems().ToList();
+				Assert.AreEqual(spectrumIdItems[0].IonTypes[0].MzArray.Values.Length, 11);
+				Assert.AreEqual(spectrumIdItems[0].IonTypes[0].MzErrorArray.Values.Length, 11);
+			}
+		}
+
+		[Test]
+		public void ParseDatabaseSequenceParamsTest()
+		{
+			using (var parser = new MzIdentMlParser(GoldenTDPortalPath))
+			{
+				List<MzIdentMlDatabaseSequence> sequences = parser.GetDatabaseSequences().ToList();
+				MzIdentMlDatabaseSequence sequence = sequences.First();
+				Assert.AreEqual(sequence.ProteinDescription, "Transmembrane protein 14C");
+				Assert.AreEqual(sequence.TaxonId, 9606);
 			}
 		}
 
@@ -90,11 +160,11 @@ namespace TopDownProteomics.Tests.IO
 				Assert.AreEqual(2, evidences.Count);
 
 				var ev = evidences[0];
-				Assert.AreEqual("DBSeq_MYG_EQUBU", ev.DatabaseSequenceId);
+				Assert.AreEqual("DBSeq_MYG_EQUBU", ev.DatabaseSequence.Id);
 				Assert.AreEqual(154, ev.End);
 				Assert.AreEqual("PE_1_1_MYG_EQUBU_0", ev.Id);
 				Assert.AreEqual(false, ev.IsDecoy);
-				Assert.AreEqual("peptide_1", ev.PeptideId);
+				Assert.AreEqual("peptide_1", ev.Peptide.Id);
 				Assert.AreEqual("-", ev.Post);
 				Assert.AreEqual("M", ev.Pre);
 				Assert.AreEqual(2, ev.Start);
@@ -131,18 +201,18 @@ namespace TopDownProteomics.Tests.IO
 
 
 
-				var proteinDetectionList = parser.GetProteinDetectionList();
+				var proteinDetectionList = parser.GetProteinDetectionLists().Single();
 				Assert.IsNotNull(proteinDetectionList);
 				Assert.AreEqual("PDL_1", proteinDetectionList.Id);
 				Assert.AreEqual(1, proteinDetectionList.ProteinAmbiguityGroups.Count);
 				Assert.AreEqual(1, proteinDetectionList.ProteinAmbiguityGroups.Count);
 				Assert.AreEqual("PAG_hit_1", proteinDetectionList.ProteinAmbiguityGroups[0].Id);
 				Assert.AreEqual("PAG_hit_1", proteinDetectionList.ProteinAmbiguityGroups[0].Id);
-				Assert.AreEqual(1, proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses.Count);
+				Assert.AreEqual(2, proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses.Count);
 				Assert.AreEqual(1, proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses[0].PeptideHypotheses.Count);
 				Assert.AreEqual(1, proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses[0].PeptideHypotheses.Count);
-				Assert.AreEqual("PE_1_1_MYG_HORSE_0", proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses[0].PeptideHypotheses[0].PeptideEvidenceId);
-				Assert.AreEqual(3, proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses[0].PeptideHypotheses[0].CvParams.Count);
+				Assert.AreEqual("PE_1_1_MYG_EQUBU_0", proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses[0].PeptideHypotheses[0].PeptideEvidenceId);
+				Assert.AreEqual(3, proteinDetectionList.ProteinAmbiguityGroups[0].ProteinDetectionHypotheses[0].CvParams.Count);
 
 
 
@@ -174,7 +244,6 @@ namespace TopDownProteomics.Tests.IO
 				Assert.AreEqual(47, id.IonTypes[0].Indices.Length);
 				Assert.AreEqual(true, id.PassesThreshold);
 				Assert.AreEqual(2, id.PeptideEvidences.Count);
-				Assert.AreEqual(2, id.PeptideEvidenceIds.Count);
 				Assert.AreEqual(2, id.Peptides.Count);
 				Assert.AreEqual(1, id.Rank);
 


### PR DESCRIPTION
Adds numerous improvements to mzIdentML parser including:
 - feature: more intelligent parsing of commonly found CV params (i.e. protein description, taxon ID, matching ion m/z and error values, etc)
 - feature: new GetSpectrumIdentificationLists method allows access to spectral data, scan number, and related search parameters
 - bug fix: allows parsing files with multiple SpectrumIdentificationProtocols and ProteinDetectionProtocols (i.e. a file with multiple search routines within it)
 - bug fix: fixes issue where number of ProteinDetectionHypotheses was wrong
 - bug fix: fixes issue where SearchDatabase properties weren't properly parsed
 - bug fix: fixes issue where link between SpectrumIdentificationItems and PeptideEvidences was incorrect
 - adds appropriate unit tests