### PR TITLE
Improve formula and composition writing

### DIFF
--- a/src/TopDownProteomics/Chemistry/ChemistryUtility.cs
+++ b/src/TopDownProteomics/Chemistry/ChemistryUtility.cs
@@ -4,24 +4,21 @@ using System.Linq;
 namespace TopDownProteomics.Chemistry
 {
     /// <summary>A class containing chemistry utility functions.</summary>
-    public class ChemistryUtility
+    public static class ChemistryUtility
     {
         /// <summary>Gets the chemical formula as a string in Hill notation.</summary>
         /// <param name="chemicalFormula">The chemical formula.</param>
         /// <returns></returns>
-        public static string GetChemicalFormulaString(IChemicalFormula chemicalFormula)
+        public static string GetChemicalFormulaString(this IChemicalFormula chemicalFormula)
         {
             // Local function for converting a single element to a string.
             string GetElementString(IEntityCardinality<IElement> element)
             {
                 if (element.Count == 0) // Don't write zero.
-                {
                     return string.Empty;
-                }
-                if (element.Count == 1) // If the count is 1, just use the symbol.
-                {
+
+                if (element.Count == 1)
                     return element.Entity.Symbol;
-                }
 
                 // In all other cases need to write out count too.
                 return $"{element.Entity.Symbol}{element.Count}";
@@ -33,12 +30,13 @@ namespace TopDownProteomics.Chemistry
 
             // Look for carbon first.  If it exists, write it and then hydrogen.
             IEntityCardinality<IElement> carbon = elements.SingleOrDefault(e => e.Entity.AtomicNumber == 6);
-            if (carbon != null && carbon.Count > 0)
+            if (carbon is not null && carbon.Count != 0)
             {
                 elementStrings.Add(GetElementString(carbon));
                 elements.Remove(carbon);
+
                 IEntityCardinality<IElement> hydrogen = elements.SingleOrDefault(e => e.Entity.AtomicNumber == 1);
-                if (hydrogen != null && hydrogen.Count > 0)
+                if (hydrogen is not null && hydrogen.Count != 0)
                 {
                     elementStrings.Add(GetElementString(hydrogen));
                     elements.Remove(hydrogen);
@@ -48,7 +46,7 @@ namespace TopDownProteomics.Chemistry
             // Write out the rest in alphabetical order.
             foreach (IEntityCardinality<IElement> element in elements.OrderBy(e => e.Entity.Symbol))
             {
-                if (element.Count > 0)
+                if (element.Count != 0)
                 {
                     elementStrings.Add(GetElementString(element));
                 }

--- a/src/TopDownProteomics/Chemistry/IChemicalFormula.cs
+++ b/src/TopDownProteomics/Chemistry/IChemicalFormula.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TopDownProteomics.Chemistry
 {
@@ -47,24 +46,10 @@ namespace TopDownProteomics.Chemistry
         /// </summary>
         /// <param name="formula"></param>
         /// <returns></returns>
+        [Obsolete("Duplicated, please use extension method ChemistryUtility.GetChemicalFormulaString().")]
         public static string GetTextFormat(this IChemicalFormula formula)
         {
-            var chemicalFormula = new StringBuilder();
-
-            foreach (var element in formula.GetElements())
-            {
-                if (element.Count != 0)
-                {
-                    chemicalFormula.Append(element.Entity.Symbol);
-
-                    if (element.Count != 1)
-                    {
-                        chemicalFormula.Append(element.Count.ToString());
-                    }
-                }
-            }
-
-            return chemicalFormula.ToString();
+            return formula.GetChemicalFormulaString();
         }
     }
 }

--- a/src/TopDownProteomics/ProForma/Validation/GlycanCompositionLookup.cs
+++ b/src/TopDownProteomics/ProForma/Validation/GlycanCompositionLookup.cs
@@ -59,7 +59,7 @@ public class GlycanCompositionLookup : IProteoformModificationLookup
             // Check for cardinality
             int numberEndIndex = currentPosition;
 
-            while (numberEndIndex < input.Length && char.IsDigit(input[numberEndIndex]))
+            while (numberEndIndex < input.Length && (char.IsDigit(input[numberEndIndex]) || input[numberEndIndex] == '-'))
                 numberEndIndex++;
 
             int cardinality = 1;

--- a/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
+++ b/src/TopDownProteomics/ProteoformHash/ChemicalProteoformHashGenerator.cs
@@ -196,7 +196,7 @@ namespace TopDownProteomics.ProteoformHash
             StringBuilder sb = new();
 
             foreach (var residue in composition.GetResidues().OrderBy(x => x.Entity.Symbol))
-                sb.Append($"{residue.Entity.Symbol}{(residue.Count > 1 ? residue.Count : string.Empty)}");
+                sb.Append($"{residue.Entity.Symbol}{(residue.Count > 1 || residue.Count < 0 ? residue.Count : string.Empty)}");
 
             return new ProFormaDescriptor(ProFormaKey.Glycan, sb.ToString());
         }

--- a/tests/TopDownProteomics.Tests/Chemistry/ChemicalFormulaTest.cs
+++ b/tests/TopDownProteomics.Tests/Chemistry/ChemicalFormulaTest.cs
@@ -416,6 +416,23 @@ namespace TopDownProteomics.Tests.Chemistry
             Assert.AreEqual(1, set.Count);
         }
 
+        [Test]
+        [TestCase("H20")]
+        [TestCase("BHC", "CHB")] // Hill notation
+        [TestCase("BH-2C-3", "C-3H-2B")] // Hill notation
+        [TestCase("CH3N3S-1")]
+        [TestCase("CH-1")]
+        [TestCase("S-10N-9", "N-9S-10")] // Hill notation, alpha
+        public void TestWritingString(string formula, string? expected = null)
+        {
+            if (expected is null)
+                expected = formula;
+
+            var result = ChemicalFormula.ParseString(formula.AsSpan(), _elementProvider);
+
+            Assert.AreEqual(expected, result.GetChemicalFormulaString());
+        }
+
         private IChemicalFormula SimpleParseTest(string formulaString, params Tuple<string, int>[] elements)
         {
             bool success = ChemicalFormula.TryParseString(formulaString, _elementProvider, out IChemicalFormula chemicalFormula);

--- a/tests/TopDownProteomics.Tests/MockElementProvider.cs
+++ b/tests/TopDownProteomics.Tests/MockElementProvider.cs
@@ -20,10 +20,15 @@ namespace TopDownProteomics.Tests
                 new Isotope(1.007825032, 0, 0.999885),
                 new Isotope(2.014101778, 1, 0.000115)
             });
-            _elements[2] = new Element(1, "He", new[]
-{
-                new Isotope(3.0160293191, 0, 1.34e-06),
-                new Isotope(4.00260325415, 1, 0.99999866)
+            _elements[2] = new Element(2, "He", new[]
+            {
+                new Isotope(3.0160293191, 1, 1.34e-06),
+                new Isotope(4.00260325415, 2, 0.99999866)
+            });
+            _elements[5] = new Element(5, "B", new[]
+            {
+                new Isotope(10.01293695, 5, 0.199),
+                new Isotope(11.00930536, 6, 0.801)
             });
             _elements[6] = new Element(6, "C", new[]
             {

--- a/tests/TopDownProteomics.Tests/ProteoformHash/ChemicalProteoformHashTests.cs
+++ b/tests/TopDownProteomics.Tests/ProteoformHash/ChemicalProteoformHashTests.cs
@@ -111,6 +111,9 @@ namespace TopDownProteomics.Tests.ProteoformHash
         {
             // Merge duplicate elements
             this.TestHash("SEQUE[Formula:CHCHO]NCE", "SEQUE[Formula:C2H2O]NCE");
+
+            // Handle negatives
+            this.TestHash("SEQUE[Formula:CH-1]NCE", "SEQUE[Formula:CH-1]NCE");
         }
 
         [Test]
@@ -121,6 +124,9 @@ namespace TopDownProteomics.Tests.ProteoformHash
 
             // Check order of elements (should be alpha)
             this.TestHash("SEQUE[Glycan:HexdHex3]NCE", "SEQUE[Glycan:dHex3Hex]NCE");
+
+            // Handle negatives
+            this.TestHash("SEQUE[Glycan:HexdHex-2]NCE", "SEQUE[Glycan:dHex-2Hex]NCE");
         }
 
         [Test]


### PR DESCRIPTION
* Obsoletes `IChemicalFormula.GetTextFormat()` in favor of `ChemistryUtility.GetChemicalFormulaString()` to remove duplication
* Fixes negative handling with `GetChemicalFormulaString()` and glycan compositions