### PR TITLE
Full v2 Spec + Proteoform Level Implementation by zrolfs

### DIFF
--- a/src/TopDownProteomics.Benchmarks/Program.cs
+++ b/src/TopDownProteomics.Benchmarks/Program.cs
@@ -15,7 +15,8 @@ namespace TopDownProteomics.Benchmarks
         private static void Main(string[] args)
         {
             //BenchmarkIsotopicEnvelopeGeneration();
-            BenchmarkChemicalFormulaAsKey();
+            //BenchmarkChemicalFormulaAsKey();
+            BenchmarkChemicalFormulaAddition();
         }
 
         private static void BenchmarkIsotopicEnvelopeGeneration()
@@ -85,6 +86,32 @@ namespace TopDownProteomics.Benchmarks
                 {
                     if (!dictionary.ContainsKey(formulas[j]))
                         dictionary.Add(formulas[j], true);
+                }
+            }
+
+            stopwatch.Stop();
+            Console.WriteLine(stopwatch.Elapsed);
+        }
+
+        private static void BenchmarkChemicalFormulaAddition()
+        {
+            IElementProvider elementProvider = new MockElementProvider();
+            IResidueProvider residueProvider = new IupacAminoAcidProvider(elementProvider);
+
+            string sequence = "MLTELEKALNSIIDVYHKYSLIKGNFHAVYRDDLKKLLETECPQYIRKKGADVWFKELDINTDGAVNFQEFLILVIKMGVAAHKKSHEESHKE";
+            var residues = sequence.Select(x => residueProvider.GetResidue(x));
+            ChemicalFormula[] formulas = residues.Select(x => x.GetChemicalFormula()).ToArray();
+
+            Dictionary<ChemicalFormula, bool> dictionary = new();
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            for (int i = 0; i < 300_000; i++)
+            {
+                var formula = ChemicalFormula.Empty;
+
+                for (int j = 0; j < formulas.Length; j++)
+                {
+                    formula = formula.Add(formulas[j]);
                 }
             }
 

--- a/src/TopDownProteomics/Biochemistry/BiochemistryUtility.cs
+++ b/src/TopDownProteomics/Biochemistry/BiochemistryUtility.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace TopDownProteomics.Biochemistry
+{
+    /// <summary>A class containing biochemistry utility functions.</summary>
+    public static class BiochemistryUtility
+    {
+        /// <summary>Determines whether the specified symbol corresponds to an ambiguous residue.</summary>
+        /// <param name="symbol">The residue symbol.</param>
+        public static bool IsAmbiguousAminoAcidResidue(char symbol)
+        {
+            return symbol == 'X' || symbol == 'J' || symbol == 'B' || symbol == 'Z';
+        }
+
+        /// <summary>Determines whether the specified sequence contains an ambiguous residue.</summary>
+        /// <param name="sequence">The sequence.</param>
+        public static bool ContainsAmbiguousAminoAcidResidue(this ReadOnlySpan<char> sequence)
+        {
+            for (int i = 0; i < sequence.Length; i++)
+            {
+                if (IsAmbiguousAminoAcidResidue(sequence[i]))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TopDownProteomics/ProForma/ProFormaTag.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaTag.cs
@@ -22,6 +22,20 @@ namespace TopDownProteomics.ProForma
         /// <summary>
         /// Initializes a new instance of the <see cref="ProFormaTag" /> class.
         /// </summary>
+        /// <param name="zeroBasedIndex">The zero-based index of the modified amino acid in the sequence.</param>
+        /// <param name="descriptors">The descriptors.</param>
+        /// <param name="hasAmbiguousSequence">if set to <c>true</c> [has ambiguous sequence].</param>
+        public ProFormaTag(int zeroBasedIndex, IList<ProFormaDescriptor> descriptors, bool hasAmbiguousSequence)
+        {
+            this.ZeroBasedStartIndex = zeroBasedIndex;
+            this.ZeroBasedEndIndex = zeroBasedIndex;
+            this.Descriptors = descriptors;
+            this.HasAmbiguousSequence = hasAmbiguousSequence;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProFormaTag" /> class.
+        /// </summary>
         /// <param name="zeroBasedStartIndex">The zero-based start index of the modified amino acid in the sequence.</param>
         /// <param name="zeroBasedEndIndex">The zero-based end index of the modified amino acid in the sequence.</param>
         /// <param name="descriptors">The descriptors.</param>
@@ -32,6 +46,21 @@ namespace TopDownProteomics.ProForma
             this.Descriptors = descriptors;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProFormaTag" /> class.
+        /// </summary>
+        /// <param name="zeroBasedStartIndex">The zero-based start index of the modified amino acid in the sequence.</param>
+        /// <param name="zeroBasedEndIndex">The zero-based end index of the modified amino acid in the sequence.</param>
+        /// <param name="descriptors">The descriptors.</param>
+        /// <param name="hasAmbiguousSequence">if set to <c>true</c> [has ambiguous sequence].</param>
+        public ProFormaTag(int zeroBasedStartIndex, int zeroBasedEndIndex, IList<ProFormaDescriptor> descriptors, bool hasAmbiguousSequence)
+        {
+            this.ZeroBasedStartIndex = zeroBasedStartIndex;
+            this.ZeroBasedEndIndex = zeroBasedEndIndex;
+            this.Descriptors = descriptors;
+            this.HasAmbiguousSequence = hasAmbiguousSequence;
+        }
+
         /// <summary>Gets the zero-based start index in the sequence.</summary>
         public int ZeroBasedStartIndex { get; }
 
@@ -40,5 +69,8 @@ namespace TopDownProteomics.ProForma
 
         /// <summary>Gets the descriptors.</summary>
         public IList<ProFormaDescriptor> Descriptors { get; }
+
+        /// <summary>Indicates whether this tag represents an ambiguous sequence.</summary>
+        public bool HasAmbiguousSequence { get; }
     }
 }

--- a/src/TopDownProteomics/ProForma/ProFormaTagGroup.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaTagGroup.cs
@@ -33,6 +33,37 @@ namespace TopDownProteomics.ProForma
             this.Members = members;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProFormaTagGroup"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="members">The members.</param>
+        /// <param name="preferredLocation">The zero-based member index for which member is the preferred location.</param>
+        public ProFormaTagGroup(string name, ProFormaKey key, string value, IList<ProFormaMembershipDescriptor> members, int preferredLocation)
+            : this(name, key, ProFormaEvidenceType.None, value, members, preferredLocation) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProFormaTagGroup" /> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="key">The key.</param>
+        /// <param name="evidenceType">Type of the evidence.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="members">The members.</param>
+        /// <param name="preferredLocation">The zero-based member index for which member is the preferred location.</param>
+        public ProFormaTagGroup(string name, ProFormaKey key, ProFormaEvidenceType evidenceType, string value,
+            IList<ProFormaMembershipDescriptor> members, int preferredLocation)
+        {
+            this.Name = name;
+            this.Key = key;
+            this.EvidenceType = evidenceType;
+            this.Value = value;
+            this.Members = members;
+            this.PreferredLocation = preferredLocation;
+        }
+
         /// <summary>The name of the group.</summary>
         public string Name { get; }
 
@@ -47,5 +78,8 @@ namespace TopDownProteomics.ProForma
 
         /// <summary>The members of the group.</summary>
         public IList<ProFormaMembershipDescriptor> Members { get; }
+
+        /// <summary>The preferred location for the modification description.</summary>
+        public int PreferredLocation { get; internal set; }
     }
 }

--- a/src/TopDownProteomics/Proteomics/FiveLevelProteoformClassifier.cs
+++ b/src/TopDownProteomics/Proteomics/FiveLevelProteoformClassifier.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using TopDownProteomics.ProForma;
+
+namespace TopDownProteomics.Proteomics
+{
+    /// <summary>
+    /// This static class contains methods for classifying proteoform identifications as defined in the following publication:
+    /// Smith, L.M., Thomas, P.M., Shortreed, M.R. et al. A five-level classification system for proteoform identifications. 
+    /// Nat Methods 16, 939–940 (2019). https://doi.org/10.1038/s41592-019-0573-x
+    /// </summary>
+    public static class FiveLevelProteoformClassifier
+    {
+        /// <summary>
+        /// Determine 5-level proteoform classification from ProForma
+        /// </summary>
+        /// <param name="parsedProteoform">ProForma proteoform </param>
+        /// <param name="genes">List of genes for this proForma </param>
+        /// <returns></returns>
+        public static string ClassifyProForma(ProFormaTerm parsedProteoform, List<string> genes)
+        {
+            bool ptmLocalized = ProFormaHasLocalizedPTMs(parsedProteoform);
+            bool ptmIdentified = ProFormaHasIdentifiedPTMs(parsedProteoform);
+            bool sequenceIdentified = ProFormaHasSequenceIdentified(parsedProteoform);
+            bool geneIdentified = genes.Count == 1;
+            return GetProteoformClassification(ptmLocalized, ptmIdentified, sequenceIdentified, geneIdentified);
+        }
+
+        /// <summary>
+        /// Determine if proteoform has all of its PTMs localized
+        /// </summary>
+        /// <param name="proteoform"></param>
+        /// <returns></returns>
+        private static bool ProFormaHasLocalizedPTMs(ProFormaTerm proteoform)
+        {
+            //check unlocalized tags 
+            if (proteoform.UnlocalizedTags == null || proteoform.UnlocalizedTags.Count == 0)
+            {
+                //check tag groups
+                if (proteoform.TagGroups != null && proteoform.TagGroups.Count != 0)
+                {
+                    foreach (ProFormaTagGroup group in proteoform.TagGroups)
+                    {
+                        if (group.Members != null && group.Members.Count > 1)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                //check tags
+                if (proteoform.Tags != null)
+                {
+                    foreach (ProFormaTag tag in proteoform.Tags)
+                    {
+                        if (tag.ZeroBasedStartIndex != tag.ZeroBasedEndIndex && tag.Descriptors.Count > 0)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                //check labile (inherently unlocalized)
+                if (proteoform.LabileDescriptors != null && proteoform.LabileDescriptors.Count != 0)
+                {
+                    return false;
+                }
+                //don't need to check N- or C-term, those are localized
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determine if proteoform has all of its PTMs identified
+        /// </summary>
+        /// <param name="proteoform"></param>
+        /// <returns></returns>
+        private static bool ProFormaHasIdentifiedPTMs(ProFormaTerm proteoform)
+        {
+            //if we observed some tags, check that they have names and/or formulas (identified) instead of just a mass shift (not identified)
+            if (proteoform.Tags != null)
+            {
+                foreach (var tag in proteoform.Tags)
+                {
+                    if (AmbiguousPtmFromDescriptor(tag.Descriptors))
+                    {
+                        return false;
+                    }
+                }
+            }
+            if (proteoform.UnlocalizedTags != null)
+            {
+                foreach (var tag in proteoform.UnlocalizedTags)
+                {
+                    if (AmbiguousPtmFromDescriptor(tag.Descriptors))
+                    {
+                        return false;
+                    }
+                }
+            }
+            if (proteoform.TagGroups != null)
+            {
+                foreach (var tag in proteoform.TagGroups)
+                {
+                    if (AmbiguousPtmFromKey(tag.Key))
+                    {
+                        return false;
+                    }
+                }
+            }
+            if (proteoform.NTerminalDescriptors != null && AmbiguousPtmFromDescriptor(proteoform.NTerminalDescriptors))
+            {
+                return false;
+            }
+            if (proteoform.CTerminalDescriptors != null && AmbiguousPtmFromDescriptor(proteoform.CTerminalDescriptors))
+            {
+                return false;
+            }
+            if (proteoform.LabileDescriptors != null && AmbiguousPtmFromDescriptor(proteoform.LabileDescriptors))
+            {
+                return false;
+            }
+            //All PTMs had an ID (or there were no PTMs)
+            return true;
+        }
+
+        /// <summary>
+        /// Given a PTM descriptor, is the PTM unknown (i.e. not have an ID)?
+        /// </summary>
+        /// <param name="descriptor"></param>
+        /// <returns></returns>
+        private static bool AmbiguousPtmFromDescriptor(IList<ProFormaDescriptor>? descriptor)
+        {
+            if (descriptor is null || descriptor.Count == 0)
+            {
+                return false;
+            }
+            else if (descriptor.Count == 1)
+            {
+                return AmbiguousPtmFromKey(descriptor[0].Key);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Given a PTM key, is the PTM unknown (i.e. not have an ID)?
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        private static bool AmbiguousPtmFromKey(ProFormaKey key)
+        {
+            return (key.Equals(ProFormaKey.Mass) || key.Equals(ProFormaKey.None));
+        }
+
+        /// <summary>
+        /// Determine if proteoform has its entire sequence identified
+        /// </summary>
+        /// <param name="proteoform"></param>
+        /// <returns></returns>
+        private static bool ProFormaHasSequenceIdentified(ProFormaTerm proteoform)
+        {
+            //easier to check if the sequence is ambiguous and then reverse the bool to find if the sequence is not ambiguous.
+            bool isAmbiguous = proteoform.Tags?.Any(x => x.HasAmbiguousSequence) ?? false;
+
+            bool containsAmbiguousCharacter = proteoform.Sequence.Contains('X') || proteoform.Sequence.Contains('J') ||
+                proteoform.Sequence.Contains('B') || proteoform.Sequence.Contains('Z');
+
+            return !(isAmbiguous || containsAmbiguousCharacter);
+        }
+
+        /// <summary>
+        /// Determine proteoform level between 1 (know everything) and 5 (only know the mass)
+        /// as defined in the publication:
+        /// Smith, L.M., Thomas, P.M., Shortreed, M.R. et al. A five-level classification system for proteoform identifications. 
+        /// Nat Methods 16, 939–940 (2019). https://doi.org/10.1038/s41592-019-0573-x
+        /// </summary>
+        /// <param name="ptmLocalized">Is the PTM localized?</param>
+        /// <param name="ptmIdentified">Do we know what the PTM is, or is it ambiguous (or an unknown mass shift?)</param>
+        /// <param name="sequenceIdentified">Do we know the proteoform sequence, or is it ambiguous?</param>
+        /// <param name="geneIdentified">Do we know which gene produced this proteoform?</param>
+        /// <returns></returns>
+        public static string GetProteoformClassification(bool ptmLocalized, bool ptmIdentified, bool sequenceIdentified, bool geneIdentified)
+        {
+            int sum = Convert.ToInt16(ptmLocalized) + Convert.ToInt16(ptmIdentified) + Convert.ToInt16(sequenceIdentified) + Convert.ToInt16(geneIdentified);
+            if (sum == 3) //level 2, but is it A, B, C, or D?
+            {
+                if (!ptmLocalized)
+                {
+                    return "2A";
+                }
+                else if (!ptmIdentified)
+                {
+                    return "2B";
+                }
+                else if (!sequenceIdentified)
+                {
+                    return "2C";
+                }
+                else //if (!geneIdentified)
+                {
+                    return "2D";
+                }
+            }
+            else
+            {
+                return (5 - sum).ToString();
+            }
+        }
+    }
+}

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
@@ -844,6 +844,11 @@ namespace TopDownProteomics.Tests
             Assert.AreEqual(3, group.Members?.Count);
             CollectionAssert.AreEquivalent(new[] { 4, 5, 7 }, group.Members.Select(x => x.ZeroBasedStartIndex));
 
+            // Check another preferred location
+            term = _parser.ParseString("EM[Oxidation]EVT[#g1]S[Phospho#g1]ES[#g1]PEK");
+            group = term.TagGroups.Single();
+            Assert.AreEqual(1, group.PreferredLocation);
+
             // The following example is not valid because a single preferred location must be chosen for a modification:
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString("EM[Oxidation]EVT[#g1]S[Phospho#g1]ES[Phospho#g1]PEK"));
         }

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
@@ -715,6 +715,12 @@ namespace TopDownProteomics.Tests
             Assert.AreEqual(ProFormaEvidenceType.None, desc1.EvidenceType);
             Assert.AreEqual("-15.9949", desc1.Value);
 
+
+
+            // RTF: In this case, need to see that the sequence started and the ? wasn't seen ... throw!
+
+
+
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString("[Oxidation]EMEVT"));
 
             term = _parser.ParseString("E[Oxidation]MEVT");
@@ -799,6 +805,12 @@ namespace TopDownProteomics.Tests
 
 
             // Check ^{count} format
+            term = _parser.ParseString("[Phospho]^2?[Acetyl]-EM[Oxidation]EVTSESPEK");
+            Assert.AreEqual(1, term.Tags?.Count);
+            Assert.IsNull(term.CTerminalDescriptors);
+            Assert.AreEqual(1, term.NTerminalDescriptors?.Count);
+            Assert.AreEqual(1, term.UnlocalizedTags?.Count);
+
             term = _parser.ParseString("[Phospho]^2[Methyl]?[Acetyl]-EM[Hydroxylation]EVTSESPEK");
             Assert.AreEqual(1, term.Tags?.Count);
             Assert.IsNull(term.CTerminalDescriptors);
@@ -832,6 +844,7 @@ namespace TopDownProteomics.Tests
             var group = term.TagGroups.Single();
             Assert.AreEqual("g1", group.Name);
             Assert.AreEqual("Phospho", group.Value);
+            Assert.AreEqual(2, group.PreferredLocation);
             Assert.AreEqual(ProFormaKey.Name, group.Key);
             Assert.AreEqual(ProFormaEvidenceType.None, group.EvidenceType);
             Assert.AreEqual(3, group.Members?.Count);
@@ -945,11 +958,24 @@ namespace TopDownProteomics.Tests
         }
 
         [Test]
-        public void NoMultipleModificationsSameSite_4_5()
+        public void MultipleModificationsSameSite_4_5()
         {
-            // Currently, there is no need to chain two mods together on the same residue, since complex glycans are not explicitly supported (see Section 3.4).
-            //  The solution in those rare cases not involving glycans is to have a single PSI-MOD/RESID  entry for the combination of mods.
-            Assert.Throws<ProFormaParseException>(() => _parser.ParseString("EM[Oxidation][Phospho]EVTSESPEK"));
+            // It is possible to represent two or more modifications on the same amino acid or group of amino acids.
+
+            var term = _parser.ParseString("EM[Oxidation][Phospho]EVTSESPEK");
+            Assert.AreEqual(2, term.Tags?.Count);
+            Assert.AreEqual(2, term.Tags?.Count(x => x.ZeroBasedStartIndex == 1));
+
+            term = _parser.ParseString("MPGLVDSNPAPPESQEKKPLK(PCCACPETKKARDACIIEKGEEHCGHLIEAHKECMRALGFKI)[Oxidation][Oxidation][half cystine][half cystine]");
+            Assert.AreEqual(4, term.Tags?.Count);
+            Assert.AreEqual(4, term.Tags?.Count(x => x.ZeroBasedStartIndex == 21));
+            Assert.AreEqual(4, term.Tags?.Count(x => x.ZeroBasedEndIndex == 62));
+
+            // The caret symbol(^), which can be used to represent multiple instances of
+            // the same unlocalized modification before the N-terminal end of the amino acid sequence
+            // (Section 4.4.1.) is however not allowed within the amino acid sequence. No extra
+            // character is required.
+            Assert.Throws<ProFormaParseException>(() => _parser.ParseString("MPGLVDSNPAPPESQEKKPLK(PCCACPETKKARDACIIEKGEEHCGHLIEAHKECMRALGFKI)[Oxidation]^2[half cystine][half cystine]"));
         }
 
         [Test]
@@ -1006,14 +1032,64 @@ namespace TopDownProteomics.Tests
             Assert.IsNotNull(term.GlobalModifications.Single().TargetAminoAcids);
             CollectionAssert.AreEquivalent(new[] { 'C', 'M' }, term.GlobalModifications.Single().TargetAminoAcids);
 
-            // Fixed modifications MUST be written prior to ambiguous modifications, and similar to ambiguity notation, 
+            // Fixed modifications MUST be written prior to ambiguous and labile modifications, and similar to ambiguity notation, 
             //  N-terminal modifications MUST be the last ones written, just next to the sequence.
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString("[Phospho]?<[MOD:01090]@C>EM[Hydroxylation]EVTSESPEK"));
+            Assert.Throws<ProFormaParseException>(() => _parser.ParseString("{Oxidation}<[MOD:01090]@C>EM[Hydroxylation]EVTSESPEK"));
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString("[Acetyl]-<[MOD:01090]@C>EM[Hydroxylation]EVTSESPEK"));
         }
 
         [Test]
-        public void InfoTag_4_7()
+        public void SequenceAmbiguity_4_7()
+        {
+            // Check multiple characters at start and end
+            var term = _parser.ParseString("(?DQ)NGTWEM[Oxidation]ESNENFEGYM[Oxidation]K(?DQ)");
+            Assert.AreEqual(4, term.Tags.Count);
+
+            var amb = term.Tags.First();
+            Assert.IsTrue(amb.HasAmbiguousSequence);
+            Assert.AreEqual(0, amb.ZeroBasedStartIndex);
+            Assert.AreEqual(1, amb.ZeroBasedEndIndex);
+            Assert.AreEqual(0, amb.Descriptors.Count);
+
+            amb = term.Tags.Last();
+            Assert.IsTrue(amb.HasAmbiguousSequence);
+            Assert.AreEqual(19, amb.ZeroBasedStartIndex);
+            Assert.AreEqual(20, amb.ZeroBasedEndIndex);
+            Assert.AreEqual(0, amb.Descriptors.Count);
+
+            // Check single character at start and end
+            term = _parser.ParseString("(?N)NGTWEM[Oxidation]ESNENFEGYM[Oxidation]K(?N)");
+            Assert.AreEqual(4, term.Tags.Count);
+
+            amb = term.Tags.First();
+            Assert.IsTrue(amb.HasAmbiguousSequence);
+            Assert.AreEqual(0, amb.ZeroBasedStartIndex);
+            Assert.AreEqual(0, amb.ZeroBasedEndIndex);
+            Assert.AreEqual(0, amb.Descriptors.Count);
+
+            amb = term.Tags.Last();
+            Assert.IsTrue(amb.HasAmbiguousSequence);
+            Assert.AreEqual(18, amb.ZeroBasedStartIndex);
+            Assert.AreEqual(18, amb.ZeroBasedEndIndex);
+            Assert.AreEqual(0, amb.Descriptors.Count);
+
+            // Check internal with a tag
+            term = _parser.ParseString("AAA(?DQ)[Oxidation]NGTWEM[Oxidation]ESNENFEGYM[Oxidation]K");
+            Assert.AreEqual(3, term.Tags.Count);
+
+            amb = term.Tags.First();
+            Assert.IsTrue(amb.HasAmbiguousSequence);
+            Assert.AreEqual(3, amb.ZeroBasedStartIndex);
+            Assert.AreEqual(4, amb.ZeroBasedEndIndex);
+            Assert.AreEqual(1, amb.Descriptors.Count);
+
+            var desc = amb.Descriptors.Single();
+            Assert.AreEqual("Oxidation", desc.Value);
+        }
+
+        [Test]
+        public void InfoTag_4_8()
         {
             // Simple info tag.
             var term = _parser.ParseString("ELV[INFO:AnyString]IS");
@@ -1044,7 +1120,7 @@ namespace TopDownProteomics.Tests
         }
 
         [Test]
-        public void JointRepresentation_4_8()
+        public void JointRepresentation_4_9()
         {
             // Alternative theoretical values
             // ELVIS[U:Phospho|+79.966331]K

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
@@ -715,12 +715,6 @@ namespace TopDownProteomics.Tests
             Assert.AreEqual(ProFormaEvidenceType.None, desc1.EvidenceType);
             Assert.AreEqual("-15.9949", desc1.Value);
 
-
-
-            // RTF: In this case, need to see that the sequence started and the ? wasn't seen ... throw!
-
-
-
             Assert.Throws<ProFormaParseException>(() => _parser.ParseString("[Oxidation]EMEVT"));
 
             term = _parser.ParseString("E[Oxidation]MEVT");

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using TopDownProteomics.ProForma;
 
 namespace TopDownProteomics.Tests.ProForma
@@ -67,11 +68,11 @@ namespace TopDownProteomics.Tests.ProForma
                 {
                     new ProFormaMembershipDescriptor(2),
                     new ProFormaMembershipDescriptor(5),
-                }),
+                }, 1), // Set preferred location
             });
             var result = _writer.WriteString(term);
 
-            Assert.AreEqual("SEQ[+14.05#test]UEN[#test]CE", result);
+            Assert.AreEqual("SEQ[#test]UEN[+14.05#test]CE", result);
 
             // With weights
             term = new ProFormaTerm("SEQUENCE", tagGroups: new[]
@@ -204,6 +205,26 @@ namespace TopDownProteomics.Tests.ProForma
         }
 
         [Test]
+        public void WriteRangeWithModInside()
+        {
+            var term = new ProFormaTerm("SEQUENCE", tags: new[]
+            {
+                new ProFormaTag(2, 5, new[]
+                {
+                    new ProFormaDescriptor(ProFormaKey.Mass, "+14.05"),
+                }),
+                new ProFormaTag(3, 3, new[]
+                {
+                    new ProFormaDescriptor(ProFormaKey.Name, "Oxidation"),
+                })
+            });
+
+            var result = _writer.WriteString(term);
+
+            Assert.AreEqual("SE(QU[Oxidation]EN)[+14.05]CE", result);
+        }
+
+        [Test]
         public void WriteUnlocalizedAmbiguousTagsTerminalMod()
         {
             var term = new ProFormaTerm("SEQUENCE", unlocalizedTags: new[]
@@ -330,6 +351,19 @@ namespace TopDownProteomics.Tests.ProForma
             result = _writer.WriteString(term);
 
             Assert.AreEqual("{Glycan:Hex}[iTRAQ4plex]-SEQ[U:Hydroxylation]UENCE", result);
+        }
+
+        [Test]
+        public void WriteSequenceAmbiguities()
+        {
+            var term = new ProFormaTerm("SEQUENCE",
+            tags: new[]
+            {
+                new ProFormaTag(2, Array.Empty<ProFormaDescriptor>(), true)
+            });
+            var result = _writer.WriteString(term);
+
+            Assert.AreEqual("SE(?Q)UENCE", result);
         }
     }
 }

--- a/tests/TopDownProteomics.Tests/ProteoformClassifierTest.cs
+++ b/tests/TopDownProteomics.Tests/ProteoformClassifierTest.cs
@@ -20,7 +20,7 @@ namespace TopDownProteomics.Tests
         [TestCase("[Phospho]?EMEVTSESPEK", 1, "2A")]
         [TestCase("EMEVT[#g1]S[#g1]ES[Phospho#g1]PEK", 1, "2A")]
         [TestCase("EM[+15.9949]EVEES[-79.9663]PEK", 1, "2B")]
-        [TestCase("EMEVEESPEK[Acetyl|Trimethyl]", 1, "2B")] // RTF: Ask into this!
+        [TestCase("EMEVEESPEK[+42|Info:likely Acetyl or Trimethyl]", 1, "2B")]
         [TestCase("EMEVEE(?SP)EK", 1, "2C")]
         [TestCase("PROTEOSFORMSISK(?N)", 1, "2C")]
         [TestCase("EMEVEESPEKB", 1, "2C")]
@@ -33,7 +33,8 @@ namespace TopDownProteomics.Tests
         [TestCase("PROT(EOSFORMS)[+19.0523]ISK(?N)", 2, "5")]
         [TestCase("PROT(?EOSFORMS)[Oxidation]ISKN", 2, "4")]
         [TestCase("PROT(?EOSFORMS)[+19.0523]ISKN", 2, "5")]
-        [TestCase("PROT(?EOSFORMS[+19.0523])ISKN", 2, "5")] // RTF: Ask into this! .. incorrect syntax, but should be handled
+        [TestCase("PROT(?EOSFORMS[+19.0523])ISKN", 2, "5")]
+        [TestCase("PROT(?EOSFORMS)IS[+19.0523]KN", 2, "4")]
         [TestCase("PROT(?EOSFORMS)IS(KK)[Acetyl]", 1, "3")]
         public static void TestProForma_ProteoformClassification(string proFormaString, int numGenes, string expectedLevel, bool checkWriter = true)
         {

--- a/tests/TopDownProteomics.Tests/ProteoformClassifierTest.cs
+++ b/tests/TopDownProteomics.Tests/ProteoformClassifierTest.cs
@@ -1,0 +1,59 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using TopDownProteomics.ProForma;
+using TopDownProteomics.Proteomics;
+
+namespace TopDownProteomics.Tests
+{
+    [TestFixture]
+    public static class ProteoformClassifierTest
+    {
+        [Test]
+        [TestCase("EMEVEESPEK", 1, "1")]
+        [TestCase("EM[UNIMOD:35]EVEES[UNIMOD:21]PEK", 1, "1")]
+        [TestCase("[+42]-EMEVEES[UNIMOD:21]PEK", 1, "2B")]
+        [TestCase("EM[UNIMOD:35]EVEESPEK-[+42]", 1, "2B")]
+        [TestCase("{Phospho}EM[UNIMOD:35]EVEESPEK", 1, "2A")]
+        [TestCase("{+80}EM[UNIMOD:35]EVEESPEK", 1, "3")]
+        [TestCase("SEQUEN[Formula:C12H20O2]CE", 1, "1")]
+        [TestCase("[Phospho]?EMEVTSESPEK", 1, "2A")]
+        [TestCase("EMEVT[#g1]S[#g1]ES[Phospho#g1]PEK", 1, "2A")]
+        [TestCase("EM[+15.9949]EVEES[-79.9663]PEK", 1, "2B")]
+        [TestCase("EMEVEESPEK[Acetyl|Trimethyl]", 1, "2B")] // RTF: Ask into this!
+        [TestCase("EMEVEE(?SP)EK", 1, "2C")]
+        [TestCase("PROTEOSFORMSISK(?N)", 1, "2C")]
+        [TestCase("EMEVEESPEKB", 1, "2C")]
+        [TestCase("EMEVEESPEKJ", 1, "2C")]
+        [TestCase("EMEVEESPEKX", 1, "2C")]
+        [TestCase("EMEVEESPEKZ", 1, "2C")]
+        [TestCase("EMEVEESPEK", 2, "2D")]
+        [TestCase("PROT(EOSFORMS)[+19.0523]ISKN", 1, "3")]
+        [TestCase("PROT(EOSFORMS)[+19.0523]ISK(?N)", 1, "4")]
+        [TestCase("PROT(EOSFORMS)[+19.0523]ISK(?N)", 2, "5")]
+        [TestCase("PROT(?EOSFORMS)[Oxidation]ISKN", 2, "4")]
+        [TestCase("PROT(?EOSFORMS)[+19.0523]ISKN", 2, "5")]
+        [TestCase("PROT(?EOSFORMS[+19.0523])ISKN", 2, "5")] // RTF: Ask into this! .. incorrect syntax, but should be handled
+        [TestCase("PROT(?EOSFORMS)IS(KK)[Acetyl]", 1, "3")]
+        public static void TestProForma_ProteoformClassification(string proFormaString, int numGenes, string expectedLevel, bool checkWriter = true)
+        {
+            List<string> genes = Enumerable.Range(0, numGenes).Select(x => x.ToString()).ToList();
+
+            //parse string
+            ProFormaParser parser = new();
+            ProFormaTerm parsedProteoform = parser.ParseString(proFormaString);
+
+            //check that the level is what we expect
+            string level = FiveLevelProteoformClassifier.ClassifyProForma(parsedProteoform, genes);
+            Assert.AreEqual(expectedLevel, level);
+
+            //check that we can write what we read
+            if (checkWriter)
+            {
+                ProFormaWriter writer = new();
+                string writtenProForma = writer.WriteString(parsedProteoform);
+                Assert.AreEqual(proFormaString, writtenProForma);
+            }
+        }
+    }
+}


### PR DESCRIPTION
After a 2-year hiatus, I finally got around to this :( ... Sorry for the delay!

Heavily influenced by @zrolfs' PR #84. I didn't take that PR directly because it had been so long that I had forgotten what we decided. Also, I wasn't sure if I'd be able to modify it. So, I worked through it myself again, pulling bits from the other PR as needed. Main difference between this PR and #84 is how to sequence ambiguities are handled. #84 adds a new List to ProFormaTerm specifically for this type, while I added a Sequence Ambiguity flag to the ProFormaTag and allowed an empty Descriptor list. There are pluses and minuses to both approaches, but I erred toward not expanding the already large ProFormaTerm API. I also added more tests to flesh out the full v2 specification (we were missing some late breaking additions).

- Adds sequence ambiguity handling
- Adds multiple tag for same site support
- Adds preferred location to tag group
- Adds 5 level classifier for proteoforms
- PR should be binary compatible as only APIs were added

Any feedback by @zrolfs or others at UW Madison (@Alexander-Sol @nbollis) would be great.