### PR TITLE
Fix to RESID ProForma writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var residLookup = ResidModificationLookup.CreateFromModifications(modifications,
 // SEQV[RESID:AA0038]ENCE
 var term = new ProFormaTerm("SEQVENCE", null, null, new List<ProFormaTag>
 {
-    new ProFormaTag(3, new[] { new ProFormaDescriptor("RESID", "AA0038") })
+    new ProFormaTag(3, new[] { new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.Resid, "RESID:AA0420") })
 });
 
 // Validate and create proteoform group

--- a/src/TopDownProteomics/ProForma/ProFormaWriter.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaWriter.cs
@@ -199,7 +199,6 @@ namespace TopDownProteomics.ProForma
                 ProFormaKey.Identifier => descriptor.EvidenceType switch
                 {
                     ProFormaEvidenceType.Observed => $"Obs:{descriptor.Value}",
-                    ProFormaEvidenceType.Resid => $"{descriptor.Value}",
                     ProFormaEvidenceType.Unimod => $"{descriptor.Value.ToUpper()}",
                     _ => descriptor.Value
                 },

--- a/src/TopDownProteomics/ProForma/ProFormaWriter.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaWriter.cs
@@ -199,7 +199,7 @@ namespace TopDownProteomics.ProForma
                 ProFormaKey.Identifier => descriptor.EvidenceType switch
                 {
                     ProFormaEvidenceType.Observed => $"Obs:{descriptor.Value}",
-                    ProFormaEvidenceType.Resid => $"RESID:{descriptor.Value}",
+                    ProFormaEvidenceType.Resid => $"{descriptor.Value}",
                     ProFormaEvidenceType.Unimod => $"{descriptor.Value.ToUpper()}",
                     _ => descriptor.Value
                 },

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
@@ -245,7 +245,7 @@ namespace TopDownProteomics.Tests.ProForma
             // RESID
             var term = new ProFormaTerm("SEQUENCE", tags: new[]
             {
-                new ProFormaTag(2, new[] { new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.Resid, "AA0420") }),
+                new ProFormaTag(2, new[] { new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.Resid, "RESID:AA0420") }),
                 new ProFormaTag(4, new[] { new ProFormaDescriptor(ProFormaKey.Name, ProFormaEvidenceType.Resid, "Test") }),
             });
             var result = _writer.WriteString(term);
@@ -360,6 +360,23 @@ namespace TopDownProteomics.Tests.ProForma
             tags: new[]
             {
                 new ProFormaTag(2, Array.Empty<ProFormaDescriptor>(), true)
+            });
+            var result = _writer.WriteString(term);
+
+            Assert.AreEqual("SE(?Q)UENCE", result);
+        }
+
+
+        [Test]
+        public void WriteSequenceAmbiguities2()
+        {
+            var term = new ProFormaTerm("SEQUENCE",
+            tags: new[]
+            {
+                new ProFormaTag(2, new[]
+                {
+                    new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.Resid, "RESID:AA00043")
+                })
             });
             var result = _writer.WriteString(term);
 

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
@@ -365,22 +365,5 @@ namespace TopDownProteomics.Tests.ProForma
 
             Assert.AreEqual("SE(?Q)UENCE", result);
         }
-
-
-        [Test]
-        public void WriteSequenceAmbiguities2()
-        {
-            var term = new ProFormaTerm("SEQUENCE",
-            tags: new[]
-            {
-                new ProFormaTag(2, new[]
-                {
-                    new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.Resid, "RESID:AA00043")
-                })
-            });
-            var result = _writer.WriteString(term);
-
-            Assert.AreEqual("SE(?Q)UENCE", result);
-        }
     }
 }


### PR DESCRIPTION
In most test cases, we show ProFormaDescriptor with a mod identifier usage as:

`new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.PsiMod, "MOD:00232")`

where the full accepted CV term is used as the "value."

For RESID, we instead had:

`new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.Resid, "AA0420")`, with the ProForma writer adding "RESID." This caused the writer to display "RESID:RESID:AA0420" in cases where the user used the full "RESID:AA0420" accession.

Updates so that different mod ontologies are handled consistently.

Also updates README to reflect change to the ProFormaDescriptor constructor signature.

