### PR TITLE
Proteoform Modification Evidence

### DIFF
--- a/src/TopDownProteomics/ProForma/Validation/BrnoModificationLookup.cs
+++ b/src/TopDownProteomics/ProForma/Validation/BrnoModificationLookup.cs
@@ -2,132 +2,133 @@
 using TopDownProteomics.Chemistry;
 using TopDownProteomics.Proteomics;
 
-namespace TopDownProteomics.ProForma.Validation
+namespace TopDownProteomics.ProForma.Validation;
+
+/// <summary>
+/// Lookup for Brno nomenclature for histone modifications.
+/// https://doi.org/10.1038/nsmb0205-110
+/// </summary>
+/// <seealso cref="IProteoformModificationLookup" />
+public class BrnoModificationLookup : IProteoformModificationLookup
 {
+    BrnoModification[] _modifications;
+
     /// <summary>
-    /// Lookup for Brno nomenclature for histone modifications.
-    /// https://doi.org/10.1038/nsmb0205-110
+    /// Initializes a new instance of the <see cref="BrnoModificationLookup"/> class.
     /// </summary>
-    /// <seealso cref="IProteoformModificationLookup" />
-    public class BrnoModificationLookup : IProteoformModificationLookup
+    /// <param name="elementProvider">The element provider.</param>
+    public BrnoModificationLookup(IElementProvider elementProvider)
     {
-        BrnoModification[] _modifications;
+        _modifications = this.CreateModificationArray(elementProvider);
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BrnoModificationLookup"/> class.
-        /// </summary>
-        /// <param name="elementProvider">The element provider.</param>
-        public BrnoModificationLookup(IElementProvider elementProvider)
+    /// <summary>
+    /// Determines whether this instance [can handle descriptor] the specified descriptor.
+    /// </summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>
+    /// <c>true</c> if this instance [can handle descriptor] the specified descriptor; otherwise, <c>false</c>.
+    /// </returns>
+    public bool CanHandleDescriptor(IProFormaDescriptor descriptor)
+    {
+        return descriptor.Key == ProFormaKey.Name &&
+            descriptor.EvidenceType == ProFormaEvidenceType.Brno &&
+            descriptor.Value != null;
+    }
+
+    /// <summary>
+    /// Gets the modification.
+    /// </summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns></returns>
+    public IProteoformMassDelta GetModification(IProFormaDescriptor descriptor)
+    {
+        string abbreviation = descriptor.Value;
+
+        switch (abbreviation)
         {
-            _modifications = this.CreateModificationArray(elementProvider);
+            case "ac": return _modifications[0];
+            case "me1": return _modifications[1];
+            case "me2s": return _modifications[2];
+            case "me2a": return _modifications[3];
+            case "me2": return _modifications[4];
+            case "me3": return _modifications[5];
+            case "ph": return _modifications[6];
+
+            default:
+                throw new ProteoformModificationLookupException($"Couldn't handle value for descriptor {descriptor}.");
+        }
+    }
+
+    private BrnoModification[] CreateModificationArray(IElementProvider elementProvider)
+    {
+        var mods = new BrnoModification[7];
+
+        var h = elementProvider.GetElement(1);
+        var c = elementProvider.GetElement(6);
+        var o = elementProvider.GetElement(8);
+        var p = elementProvider.GetElement(15);
+
+        mods[0] = new BrnoModification("B:ac", new[]
+        {
+            new EntityCardinality<IElement>(c, 2),
+            new EntityCardinality<IElement>(h, 2),
+            new EntityCardinality<IElement>(o, 1)
+        });
+        mods[1] = new BrnoModification("B:me1", new[]
+        {
+            new EntityCardinality<IElement>(c, 1),
+            new EntityCardinality<IElement>(h, 2)
+        });
+
+        var me2 = new[]
+        {
+            new EntityCardinality<IElement>(c, 2),
+            new EntityCardinality<IElement>(h, 4)
+        };
+        mods[2] = new BrnoModification("B:me2s", me2);
+        mods[3] = new BrnoModification("B:me2a", me2);
+        mods[4] = new BrnoModification("B:me2", me2);
+
+        mods[5] = new BrnoModification("B:me3", new[]
+        {
+            new EntityCardinality<IElement>(c, 3),
+            new EntityCardinality<IElement>(h, 6)
+        });
+        mods[6] = new BrnoModification("B:ph", new[]
+        {
+            new EntityCardinality<IElement>(h, 1),
+            new EntityCardinality<IElement>(o, 3),
+            new EntityCardinality<IElement>(p, 1),
+        });
+
+        return mods;
+    }
+
+    private class BrnoModification : IProteoformOntologyDelta
+    {
+        public BrnoModification(string abbreviation, IReadOnlyCollection<IEntityCardinality<IElement>> elements)
+        {
+            this.Abbreviation = abbreviation;
+            _elements = elements;
         }
 
-        /// <summary>
-        /// Determines whether this instance [can handle descriptor] the specified descriptor.
-        /// </summary>
-        /// <param name="descriptor">The descriptor.</param>
-        /// <returns>
-        /// <c>true</c> if this instance [can handle descriptor] the specified descriptor; otherwise, <c>false</c>.
-        /// </returns>
-        public bool CanHandleDescriptor(IProFormaDescriptor descriptor)
+        private IReadOnlyCollection<IEntityCardinality<IElement>> _elements;
+        string Abbreviation { get; }
+
+        public string Id => this.Abbreviation;
+
+        public string Name => this.Abbreviation;
+
+        public ProFormaEvidenceType EvidenceType => ProFormaEvidenceType.Brno;
+
+        public ChemicalFormula GetChemicalFormula() => new ChemicalFormula(_elements);
+
+        public ProFormaDescriptor GetProFormaDescriptor()
         {
-            return descriptor.Key == ProFormaKey.Name && 
-                descriptor.EvidenceType == ProFormaEvidenceType.Brno && 
-                descriptor.Value != null;
+            return new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.None, this.Abbreviation);
         }
 
-        /// <summary>
-        /// Gets the modification.
-        /// </summary>
-        /// <param name="descriptor">The descriptor.</param>
-        /// <returns></returns>
-        public IProteoformMassDelta GetModification(IProFormaDescriptor descriptor)
-        {
-            string abbreviation = descriptor.Value;
-
-            switch (abbreviation)
-            {
-                case "ac": return _modifications[0];
-                case "me1": return _modifications[1];
-                case "me2s": return _modifications[2];
-                case "me2a": return _modifications[3];
-                case "me2": return _modifications[4];
-                case "me3": return _modifications[5];
-                case "ph": return _modifications[6];
-
-                default:
-                    throw new ProteoformModificationLookupException($"Couldn't handle value for descriptor {descriptor}.");
-            }
-        }
-
-        private BrnoModification[] CreateModificationArray(IElementProvider elementProvider)
-        {
-            var mods = new BrnoModification[7];
-
-            var h = elementProvider.GetElement(1);
-            var c = elementProvider.GetElement(6);
-            var o = elementProvider.GetElement(8);
-            var p = elementProvider.GetElement(15);
-
-            mods[0] = new BrnoModification("B:ac", new[]
-            {
-                new EntityCardinality<IElement>(c, 2),
-                new EntityCardinality<IElement>(h, 2),
-                new EntityCardinality<IElement>(o, 1)
-            });
-            mods[1] = new BrnoModification("B:me1", new[]
-            {
-                new EntityCardinality<IElement>(c, 1),
-                new EntityCardinality<IElement>(h, 2)
-            });
-
-            var me2 = new[]
-            {
-                new EntityCardinality<IElement>(c, 2),
-                new EntityCardinality<IElement>(h, 4)
-            };
-            mods[2] = new BrnoModification("B:me2s", me2);
-            mods[3] = new BrnoModification("B:me2a", me2);
-            mods[4] = new BrnoModification("B:me2", me2);
-
-            mods[5] = new BrnoModification("B:me3", new[]
-            {
-                new EntityCardinality<IElement>(c, 3),
-                new EntityCardinality<IElement>(h, 6)
-            });
-            mods[6] = new BrnoModification("B:ph", new[]
-            {
-                new EntityCardinality<IElement>(h, 1),
-                new EntityCardinality<IElement>(o, 3),
-                new EntityCardinality<IElement>(p, 1),
-            });
-
-            return mods;
-        }
-
-        private class BrnoModification : IProteoformOntologyDelta
-        {
-            public BrnoModification(string abbreviation, IReadOnlyCollection<IEntityCardinality<IElement>> elements)
-            {
-                this.Abbreviation = abbreviation;
-                _elements = elements;
-            }
-
-            private IReadOnlyCollection<IEntityCardinality<IElement>> _elements;
-            string Abbreviation { get; }
-
-            public string Id => this.Abbreviation;
-
-            public string Name => this.Abbreviation;
-
-            public ChemicalFormula GetChemicalFormula() => new ChemicalFormula(_elements);
-
-            public ProFormaDescriptor GetProFormaDescriptor()
-            {
-                return new ProFormaDescriptor(ProFormaKey.Identifier, ProFormaEvidenceType.None, this.Abbreviation);
-            }
-
-            public double GetMass(MassType massType) => this.GetChemicalFormula().GetMass(massType);
-        }
+        public double GetMass(MassType massType) => this.GetChemicalFormula().GetMass(massType);
     }
 }

--- a/src/TopDownProteomics/ProForma/Validation/ModificationLookupBase.cs
+++ b/src/TopDownProteomics/ProForma/Validation/ModificationLookupBase.cs
@@ -1,171 +1,172 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using TopDownProteomics.Chemistry;
 using TopDownProteomics.Proteomics;
 
-namespace TopDownProteomics.ProForma.Validation
+namespace TopDownProteomics.ProForma.Validation;
+
+/// <summary>
+/// Base class for modification lookup.
+/// </summary>
+/// <seealso cref="IProteoformModificationLookup" />
+public abstract class ModificationLookupBase<T> : IProteoformModificationLookup where T : IIdentifiable
 {
+    private IProteoformOntologyDelta[]? _modifications;
+    private Dictionary<string, IProteoformOntologyDelta>? _modificationNames;
+
     /// <summary>
-    /// Base class for modification lookup.
+    /// Gets the modification array.
     /// </summary>
-    /// <seealso cref="IProteoformModificationLookup" />
-    public abstract class ModificationLookupBase<T> : IProteoformModificationLookup where T : IIdentifiable
+    /// <param name="modifications">The modifications.</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException">modifications</exception>
+    protected void SetupModificationArray(IEnumerable<T> modifications)
     {
-        private IProteoformMassDelta[]? _modifications;
-        private Dictionary<string, IProteoformMassDelta>? _modificationNames;
+        if (modifications == null) throw new ArgumentNullException(nameof(modifications));
 
-        /// <summary>
-        /// Gets the modification array.
-        /// </summary>
-        /// <param name="modifications">The modifications.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException">modifications</exception>
-        protected void SetupModificationArray(IEnumerable<T> modifications)
+        _modificationNames = new Dictionary<string, IProteoformOntologyDelta>();
+
+        var modArray = new IProteoformOntologyDelta[10000]; // More IDs than will ever exist
+        int maxId = -1;
+        foreach (T modification in modifications)
         {
-            if (modifications == null) throw new ArgumentNullException(nameof(modifications));
+            ChemicalFormula? chemicalFormula = this.GetChemicalFormula(modification);
 
-            _modificationNames = new Dictionary<string, IProteoformMassDelta>();
+            int id = Convert.ToInt32(this.RemovePrefix(modification.Id));
 
-            var modArray = new IProteoformMassDelta[10000]; // More IDs than will ever exist
-            int maxId = -1;
-            foreach (T modification in modifications)
+            if (chemicalFormula != null)
+                modArray[id] = new ModificationWrapper(modification, chemicalFormula, this.EvidenceType);
+
+            // Keep all the way up to the max passed in, even if it turns out to be NULL
+            maxId = Math.Max(maxId, id);
+
+            if (_modificationNames != null)
             {
-                ChemicalFormula? chemicalFormula = this.GetChemicalFormula(modification);
+                // HACK for obsolete PSI-MOD terms with same name as something else ... skip
+                if (modification.Id == "MOD:00949" || modification.Id == "MOD:01966") continue;
 
-                int id = Convert.ToInt32(this.RemovePrefix(modification.Id));
-
-                if (chemicalFormula != null)
-                    modArray[id] = new ModificationWrapper(modification, chemicalFormula);
-
-                // Keep all the way up to the max passed in, even if it turns out to be NULL
-                maxId = Math.Max(maxId, id);
-
-                if (_modificationNames != null)
-                {
-                    // HACK for obsolete PSI-MOD terms with same name as something else ... skip
-                    if (modification.Id == "MOD:00949" || modification.Id == "MOD:01966") continue;
-
-                    _modificationNames.Add(modification.Name, modArray[id]);
-                }
+                _modificationNames.Add(modification.Name, modArray[id]);
             }
-
-            Array.Resize(ref modArray, maxId + 1);
-
-            _modifications = modArray;
         }
 
-        /// <summary>
-        /// Gets the chemical formula.
-        /// </summary>
-        /// <param name="modification">The modification.</param>
-        /// <returns></returns>
-        protected abstract ChemicalFormula? GetChemicalFormula(T modification);
+        Array.Resize(ref modArray, maxId + 1);
 
-        /// <summary>
-        /// Determines whether this instance [can handle descriptor] the specified descriptor.
-        /// </summary>
-        /// <param name="descriptor">The descriptor.</param>
-        /// <returns>
-        /// <c>true</c> if this instance [can handle descriptor] the specified descriptor; otherwise, <c>false</c>.
-        /// </returns>
-        public virtual bool CanHandleDescriptor(IProFormaDescriptor descriptor)
+        _modifications = modArray;
+    }
+
+    /// <summary>
+    /// Gets the chemical formula.
+    /// </summary>
+    /// <param name="modification">The modification.</param>
+    /// <returns></returns>
+    protected abstract ChemicalFormula? GetChemicalFormula(T modification);
+
+    /// <summary>
+    /// Determines whether this instance [can handle descriptor] the specified descriptor.
+    /// </summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>
+    /// <c>true</c> if this instance [can handle descriptor] the specified descriptor; otherwise, <c>false</c>.
+    /// </returns>
+    public virtual bool CanHandleDescriptor(IProFormaDescriptor descriptor)
+    {
+        var nonDefault = descriptor.EvidenceType == this.EvidenceType &&
+            (descriptor.Key == ProFormaKey.Name || descriptor.Key == ProFormaKey.Identifier);
+
+        if (!this.IsDefaultModificationType || nonDefault)
+            return nonDefault;
+
+        // If this is the default modification type, allow no evidence name check.
+        return _modificationNames?.ContainsKey(descriptor.Value) ?? false;
+    }
+
+    /// <summary>The ProForma key.</summary>
+    protected abstract ProFormaEvidenceType EvidenceType { get; }
+
+    /// <summary>
+    /// Removes the prefix.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns></returns>
+    protected abstract string RemovePrefix(string value);
+
+    /// <summary>
+    /// Gets a value indicating whether this instance is default modification type.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this instance is default modification type; otherwise, <c>false</c>.
+    /// </value>
+    protected virtual bool IsDefaultModificationType => false;
+
+    /// <summary>
+    /// Gets the modification.
+    /// </summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns></returns>
+    public virtual IProteoformMassDelta GetModification(IProFormaDescriptor descriptor)
+    {
+        if (_modifications == null)
+            throw new Exception("Modification array in not initialized.");
+
+        if (descriptor.Value == null)
+            throw new ProteoformModificationLookupException($"Value is NULL in descriptor {descriptor}.");
+
+        if (descriptor.Key == ProFormaKey.Name)
         {
-            var nonDefault = descriptor.EvidenceType == this.EvidenceType &&
-                (descriptor.Key == ProFormaKey.Name || descriptor.Key == ProFormaKey.Identifier);
+            string value = descriptor.Value;
 
-            if (!this.IsDefaultModificationType || nonDefault)
-                return nonDefault;
+            if (_modificationNames != null)
+            {
+                if (!_modificationNames.ContainsKey(value))
+                    throw new ProteoformModificationLookupException($"Could not find modification using Name in descriptor {descriptor}.");
 
-            // If this is the default modification type, allow no evidence name check.
-            return _modificationNames?.ContainsKey(descriptor.Value) ?? false;
+                return _modificationNames[value];
+            }
+        }
+        else if (descriptor.Key == ProFormaKey.Identifier)
+        {
+            string value = this.RemovePrefix(descriptor.Value);
+
+            if (int.TryParse(value, out int id))
+            {
+                if (id < 0 || id > _modifications.Length - 1 || _modifications[id] == null)
+                    throw new ProteoformModificationLookupException($"Could not find modification using ID in descriptor {descriptor}.");
+
+                return _modifications[id];
+            }
+
+            throw new ProteoformModificationLookupException($"Invalid integer in descriptor {descriptor}.");
         }
 
-        /// <summary>The ProForma key.</summary>
-        protected abstract ProFormaEvidenceType EvidenceType { get; }
+        throw new ProteoformModificationLookupException($"Couldn't handle value for descriptor {descriptor}.");
+    }
 
-        /// <summary>
-        /// Removes the prefix.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        /// <returns></returns>
-        protected abstract string RemovePrefix(string value);
+    private class ModificationWrapper : IProteoformOntologyDelta
+    {
+        private ChemicalFormula _chemicalFormula;
 
-        /// <summary>
-        /// Gets a value indicating whether this instance is default modification type.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is default modification type; otherwise, <c>false</c>.
-        /// </value>
-        protected virtual bool IsDefaultModificationType => false;
-
-        /// <summary>
-        /// Gets the modification.
-        /// </summary>
-        /// <param name="descriptor">The descriptor.</param>
-        /// <returns></returns>
-        public virtual IProteoformMassDelta GetModification(IProFormaDescriptor descriptor)
+        public ModificationWrapper(T modification, ChemicalFormula chemicalFormula, ProFormaEvidenceType evidenceType)
         {
-            if (_modifications == null)
-                throw new Exception("Modification array in not initialized.");
-
-            if (descriptor.Value == null)
-                throw new ProteoformModificationLookupException($"Value is NULL in descriptor {descriptor}.");
-
-            if (descriptor.Key == ProFormaKey.Name)
-            {
-                string value = descriptor.Value;
-
-                if (_modificationNames != null)
-                {
-                    if (!_modificationNames.ContainsKey(value))
-                        throw new ProteoformModificationLookupException($"Could not find modification using Name in descriptor {descriptor}.");
-
-                    return _modificationNames[value];
-                }
-            }
-            else if (descriptor.Key == ProFormaKey.Identifier)
-            {
-                string value = this.RemovePrefix(descriptor.Value);
-
-                if (int.TryParse(value, out int id))
-                {
-                    if (id < 0 || id > _modifications.Length - 1 || _modifications[id] == null)
-                        throw new ProteoformModificationLookupException($"Could not find modification using ID in descriptor {descriptor}.");
-
-                    return _modifications[id];
-                }
-
-                throw new ProteoformModificationLookupException($"Invalid integer in descriptor {descriptor}.");
-            }
-
-            throw new ProteoformModificationLookupException($"Couldn't handle value for descriptor {descriptor}.");
+            _chemicalFormula = chemicalFormula;
+            Modification = modification;
+            EvidenceType = evidenceType;
         }
 
-        private class ModificationWrapper : IProteoformOntologyDelta
+        public T Modification { get; }
+
+        public string Id => this.Modification.Id;
+
+        public string Name => this.Modification.Name;
+
+        public ProFormaEvidenceType EvidenceType { get; }
+
+        public ChemicalFormula GetChemicalFormula() => _chemicalFormula;
+
+        public ProFormaDescriptor GetProFormaDescriptor()
         {
-            private ChemicalFormula _chemicalFormula;
-
-            public ModificationWrapper(T modification, ChemicalFormula chemicalFormula)
-            {
-                this.Modification = modification;
-                _chemicalFormula = chemicalFormula;
-            }
-
-            public T Modification { get; }
-
-            public string Id => this.Modification.Id;
-
-            public string Name => this.Modification.Name;
-
-            public ChemicalFormula GetChemicalFormula() => _chemicalFormula;
-
-            public ProFormaDescriptor GetProFormaDescriptor()
-            {
-                throw new NotImplementedException();
-            }
-
-            public double GetMass(MassType massType) => _chemicalFormula.GetMass(massType);
+            throw new NotImplementedException();
         }
+
+        public double GetMass(MassType massType) => _chemicalFormula.GetMass(massType);
     }
 }

--- a/src/TopDownProteomics/Proteomics/IProteoformOntologyDelta.cs
+++ b/src/TopDownProteomics/Proteomics/IProteoformOntologyDelta.cs
@@ -1,7 +1,12 @@
-﻿namespace TopDownProteomics.Proteomics
+﻿using TopDownProteomics.ProForma;
+
+namespace TopDownProteomics.Proteomics;
+
+/// <summary>A delta modification from an ontology that has been applied to a proteoform.</summary>
+/// <seealso cref="IIdentifiable" />
+/// <seealso cref="IProteoformFormulaProteoformDelta" />
+public interface IProteoformOntologyDelta : IIdentifiable, IProteoformFormulaProteoformDelta
 {
-    /// <summary>A delta modification from an ontology that has been applied to a proteoform.</summary>
-    /// <seealso cref="IIdentifiable" />
-    /// <seealso cref="IProteoformFormulaProteoformDelta" />
-    public interface IProteoformOntologyDelta : IIdentifiable, IProteoformFormulaProteoformDelta { }
+    /// <summary>The type of the evidence for this ontology term.</summary>
+    ProFormaEvidenceType EvidenceType { get; }
 }


### PR DESCRIPTION
Adds an Evidence enum to the proteoform modification ontology interface so one can tell where the modification came from downstream.